### PR TITLE
#166650872 Implement functionality for mark sold/rented button

### DIFF
--- a/UI/assets/css/dashboard.css
+++ b/UI/assets/css/dashboard.css
@@ -584,3 +584,109 @@
         padding-right: 0.3rem;
     }
 }
+/* Mark/unMark rented/sold */
+.properties-dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,.5);
+    z-index: 999999;
+    width: 100%;
+    height: 100%;
+}
+.properties-dialog-overlay__confirm {
+    width: 310px;
+    margin: 150px auto 0 auto;
+    background-color: #fff;
+    box-shadow: 0 0 20px rgba(0,0,0,.2);
+    border-radius: 3px;
+    animation: navbar-slide-in 0.8s ease-in-out;
+}
+.properties-dialog-overlay__heading {
+    padding: 10px 10px;
+    background-color: #f6f7f9;
+    border-bottom: 1px solid #e5e5e5;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.properties-dialog-overlay__header{
+    color: #34495e;
+    text-align: center;
+    text-transform: capitalize;
+    margin: 0;
+    font-weight: 500;
+}
+.properties-dialog-overlay__close-btn{
+   color: #c4c5c7;
+   cursor: pointer;
+   transition: all .5s ease; 
+   outline: none;
+   font-size: 1rem;
+   background-color: #f6f7f9; 
+   border: none;
+}
+
+.properties-dialog-overlay__close-btn:hover{
+    color: #d32f2f;
+
+}
+.properties-dialog-overlay__body{
+    padding: 12px 10px;
+    background: #fff;
+}
+.properties-dialog-overlay__body-text{
+    font-size: 1rem;
+    color: #1a1c1eeb;
+    margin: 0;
+    font-weight: 350;
+}
+.properties-dialog-overlay__footer{
+    border-top: 1px solid #e5e5e5;
+    padding: 8px 10px;
+    display: flex;
+    justify-content: flex-end;
+    background-color: #f6f7f9;
+}
+.properties-dialog-overlay__cancel-btn,.properties-dialog-overlay__proceed-btn{
+    line-height: 14px;
+    display: inline-block;
+    font-weight: 400;
+    text-align: center;
+    white-space: nowrap;
+    box-shadow: 0 1px 6px rgba(57,73,76,0.35);
+    color: #fff;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    transition: all 0.6s ease-in-out;
+    text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.16);
+    text-transform: capitalize;
+    cursor: pointer; 
+    padding: 4px 10px;
+}
+.properties-dialog-overlay__proceed-btn{
+    background-color: #f44336;
+    border: 1px solid #d32f2f;
+    margin-left: 10px;
+}
+.properties-dialog-overlay__proceed-btn:hover{
+    background-color: #d32f2f;
+}
+.properties-dialog-overlay__cancel-btn{
+    background-color: #737070;
+    border: 1px solid #7a7b7d;
+}
+.properties-dialog-overlay__cancel-btn:hover{
+    background-color: #a9a5a5;
+}
+  
+@media only screen and (max-width: 357px){
+    .properties-dialog-overlay__confirm {
+        width: 280px;
+    }
+    .properties-dialog-overlay__body-text{
+        font-size: 0.7rem;
+    }
+}

--- a/UI/assets/js/dashboard.js
+++ b/UI/assets/js/dashboard.js
@@ -58,8 +58,79 @@ const selectNextPropertyPage = () => {
         e.preventDefault();
     }
 }
+//Mark property sold/rented Functions
+//Utilities that adds and removes Modals
+const addModalToDOM = (innerhtml, childSelector, position) => {
+    const childModal = document.querySelector(childSelector);
+    const parentElem = document.querySelector('body');
+    if(childModal) parentElem.removeChild(childModal);
+    parentElem.insertAdjacentHTML(position,innerhtml);
+}
+const removeModalFromDom = (childSelector) => {
+    const childModal = document.querySelector(childSelector);
+    const parentElem = document.querySelector('body');
+    if(!parentElem) return;
+    if(!childModal) return;
+    parentElem.removeChild(childModal);
+}
+const generateHTML = (CallToAction,actionId,action) => {
+    return `
+    <div class="properties-dialog-overlay">
+        <div class="properties-dialog-overlay__confirm">   
+            <div class="properties-dialog-overlay__heading">
+                <h5 class="properties-dialog-overlay__header">Please confirm Action</h5>
+                <button class="properties-dialog-overlay__close-btn">
+                    <i class="far fa-window-close properties-dialog-close"></i>
+                </button>
+            </div>
+            <div class="properties-dialog-overlay__body">
+                <p class="properties-dialog-overlay__body-text">${CallToAction}</p>
+            </div>
+            <div class="properties-dialog-overlay__footer">
+                <button class="properties-dialog-overlay__cancel-btn" >no</button>
+                <button class="properties-dialog-overlay__proceed-btn" id="${actionId}">${action}</button>
+            </div>
+        </div>
+    </div>
+`;
+}
+const enableCloseModal = () => {
+    const modalCloseBtn = document.querySelector('.properties-dialog-overlay__close-btn');
+    const modalCancelBtn = document.querySelector('.properties-dialog-overlay__cancel-btn');
+    const closeNow = (e) => {
+            removeModalFromDom('.properties-dialog-overlay');
+            e.preventDefault();
+        }
+    modalCloseBtn.addEventListener('click',closeNow);
+    modalCancelBtn.addEventListener('click',closeNow);
+}
+const proceedWithMark = (selector) => {
+    const modalProceedBtn = document.querySelector(selector);
+    const proceed = (e) => {
+        window.location.assign('/UI/manage-properties.html');
+        e.preventDefault();
+        }
+        modalProceedBtn.addEventListener('click',proceed);
+}
+//Adds and removes  Modal on click of Mark as rented/sold
+const markOrUnSoldOrRented = () => {
+   const markBtns = document.querySelectorAll('.property-list__mark');
+    const innerhtml = generateHTML('Would you like to proceed?','proceed','Yes');
+   const popUpModal = (e) => {
+        addModalToDOM(innerhtml,'.properties-dialog-overlay','afterbegin');
+        enableCloseModal();
+        proceedWithMark('#proceed');
+        e.preventDefault();
+   }
+   if(!markBtns) return;
+   markBtns.forEach((btn)=> {
+       btn.addEventListener('click',popUpModal);
+   })
+}
+
 const startDashApp = () => {
     showSideNav();
     selectNextPropertyPage();
+    markOrUnSoldOrRented();
 }
 startDashApp();

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -131,7 +131,7 @@
                    </a> 
                 </div>
                 <div class="dashboard-main__menu">
-                        <a href="#" class="dashboard-main__menu-link">
+                        <a href="manage-properties.html" class="dashboard-main__menu-link">
                              <div class="dashboard-main__menu-img-block">
                                      <span class="dashboard-main__menu-icon">
                                          <div class="dashboard-main__menu-icon-pulse"></div>


### PR DESCRIPTION
#### What does this PR do?
Add functionality for the **mark sold/rented button** on manage-properties page

#### Description of Task to be completed?
Carry out the following Tasks 
- Add a link to manage-properties.html on a pointer anchor tag
- Write a function that dynamically creates a modal requesting that a user confirms his/her choice of action when the **mark sold/rented button** is clicked

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-UI-dashboard-mark-property-166650872 branch and launch manage-properties.html

#### What are the relevant pivotal tracker stories?
#166650872

#### Screenshot
<img width="948" alt="mark-sold-rented" src="https://user-images.githubusercontent.com/40744698/59883931-2d936780-93a6-11e9-8405-00ee3f6cefa0.PNG">

