### PR TITLE
#166651212 Add functionality to delete button on manage-properties page

### DIFF
--- a/UI/assets/css/dashboard.css
+++ b/UI/assets/css/dashboard.css
@@ -466,6 +466,18 @@
     top: 7px;
     right: 9px;
 }
+.property-list__img-block-mode--available{
+    color: #fff;
+    text-transform: uppercase;
+    font-size: 12px;
+    background: #15da25b3;
+    border-radius: 50px;
+    padding: 5px 13px;
+    text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.16);
+    position: absolute;
+    top: 7px;
+    right: 9px;  
+}
 .property-list__preview,.property-list__edit,.property-list__mark,.property-list__delete{
     padding: 11px 20px;
     line-height: 14px;

--- a/UI/assets/js/dashboard.js
+++ b/UI/assets/js/dashboard.js
@@ -127,10 +127,34 @@ const markOrUnSoldOrRented = () => {
        btn.addEventListener('click',popUpModal);
    })
 }
-
+//Delete property Functions
+//Popup Modal on click of the delete button
+const proceedWithDelete = (id) => {
+    const modalDeleteBtn = document.querySelector(id);
+    const proceed = (e) => {
+        window.location.assign('/UI/manage-properties.html');
+        e.preventDefault();
+        }
+        modalDeleteBtn.addEventListener('click',proceed);
+}
+const deleteProperty = () => {
+    const deleteBtns = document.querySelectorAll('.property-list__delete');
+    const innerhtml = generateHTML('Do you want to this Delete Property?','delete','Yes');
+    const popUpModal = (e) => {
+        addModalToDOM(innerhtml,'.properties-dialog-overlay','afterbegin');
+        enableCloseModal();
+        proceedWithDelete('#delete');
+        e.preventDefault();
+   }
+   if(!deleteBtns) return;
+   deleteBtns.forEach((btn)=> {
+       btn.addEventListener('click',popUpModal);
+   })
+}
 const startDashApp = () => {
     showSideNav();
     selectNextPropertyPage();
     markOrUnSoldOrRented();
+    deleteProperty();
 }
 startDashApp();

--- a/UI/manage-properties.html
+++ b/UI/manage-properties.html
@@ -91,7 +91,7 @@
                     <li class="dashboard-sidenav__board-menu-item dashboard-sidenav__board-menu-item--display">
                             <a href="#" class="dashboard-sidenav__board-menu-link">
                                 <span class="dashboard-sidenav__board-menu-icon">
-                                    <i class="fas fa-home"></i>
+                                    <i class="fas fa-power-off"></i>
                                 </span> 
                                 Log Out
                             </a>
@@ -175,7 +175,7 @@
                             <div class="property-list__img-block">
                                 <p class="property-list__img-block-mode">For Rent</p>
                                 <p class="property-list__img-block-mode--sold">Rented</p>
-                                <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+                                <img src="assets/images/1.jpg" class="property-list__img" alt="Property Image">
                             </div>
                             <div class="property-list__summary">
                                 <div class="property-list__content-header">
@@ -232,8 +232,8 @@
                     <li class="property-list__item" propertyId transactMode>
                             <div class="property-list__img-block">
                                 <p class="property-list__img-block-mode">For Rent</p>
-                                <p class="property-list__img-block-mode--sold">Rented</p>
-                                <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+                                <p class="property-list__img-block-mode--available">Available</p>
+                                <img src="assets/images/2.jpg" class="property-list__img" alt="Property Image">
                             </div>
                             <div class="property-list__summary">
                                 <div class="property-list__content-header">
@@ -288,8 +288,8 @@
                     </li>  
                     <li class="property-list__item" propertyId transactMode>
                         <div class="property-list__img-block">
-                            <p class="property-list__img-block-mode">For Rent</p>
-                            <p class="property-list__img-block-mode--sold">Rented</p>
+                            <p class="property-list__img-block-mode">For Sale</p>
+                            <p class="property-list__img-block-mode--available">Available</p>
                             <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
                         </div>
                         <div class="property-list__summary">
@@ -347,7 +347,7 @@
                     <div class="property-list__img-block">
                         <p class="property-list__img-block-mode">For Rent</p>
                         <p class="property-list__img-block-mode--sold">Rented</p>
-                        <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+                        <img src="assets/images/3.jpg" class="property-list__img" alt="Property Image">
                     </div>
                     <div class="property-list__summary">
                         <div class="property-list__content-header">
@@ -402,9 +402,9 @@
             </li>                
             <li class="property-list__item" propertyId transactMode>
                 <div class="property-list__img-block">
-                    <p class="property-list__img-block-mode">For Rent</p>
-                    <p class="property-list__img-block-mode--sold">Rented</p>
-                    <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+                    <p class="property-list__img-block-mode">For Sale</p>
+                    <p class="property-list__img-block-mode--sold">Sold</p>
+                    <img src="assets/images/9.jpg" class="property-list__img" alt="Property Image">
                 </div>
                 <div class="property-list__summary">
                     <div class="property-list__content-header">
@@ -461,7 +461,7 @@
             <div class="property-list__img-block">
                 <p class="property-list__img-block-mode">For Rent</p>
                 <p class="property-list__img-block-mode--sold">Rented</p>
-                <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+                <img src="assets/images/4.jpg" class="property-list__img" alt="Property Image">
             </div>
             <div class="property-list__summary">
                 <div class="property-list__content-header">
@@ -518,7 +518,7 @@
         <div class="property-list__img-block">
             <p class="property-list__img-block-mode">For Rent</p>
             <p class="property-list__img-block-mode--sold">Rented</p>
-            <img src="assets/images/property-1.jpg" class="property-list__img" alt="Property Image">
+            <img src="assets/images/2.jpg" class="property-list__img" alt="Property Image">
         </div>
         <div class="property-list__summary">
             <div class="property-list__content-header">


### PR DESCRIPTION
#### What does this PR do?
Add functionality to delete button enabling user to confirm a delete action before it takes place

#### Description of Task to be completed?
Carry out the following Tasks 
- Implement a function that adds a modal to the DOM when the delete button is clicked
- Changed image path on manage-properties page for a better preview of page design

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-UI-dashboard-delete-property-166651212 branch and launch manage-properties.html

#### What are the relevant pivotal tracker stories?
#166651212

#### Screenshot
<img width="948" alt="delete-property" src="https://user-images.githubusercontent.com/40744698/59885599-4d795a00-93ab-11e9-9b40-7a8df552e10f.PNG">

