### PR TITLE
#166652392 Add functionality to preview property

### DIFF
--- a/UI/assets/js/dashboard.js
+++ b/UI/assets/js/dashboard.js
@@ -333,8 +333,16 @@ const handleUpdatePropertyEvent = ()=> {
         }
     })
 }
-
-
+//Preview Property 
+const handlePropertyPreview = ()=> {
+    const previewButtons = document.querySelectorAll('.property-list__preview');
+    if(!previewButtons) return;
+    previewButtons.forEach(el =>{
+        el.onclick = () => {
+            window.location.assign('/UI/view-property.html');
+        }
+    })
+}
 const startDashApp = () => {
     showSideNav();
     selectNextPropertyPage();
@@ -350,5 +358,6 @@ const startDashApp = () => {
     updateGenderSelector();
     updateLabelWithFileName();
     handleUpdatePropertyEvent();
+    handlePropertyPreview();
 }
 startDashApp();

--- a/UI/view-profile.html
+++ b/UI/view-profile.html
@@ -81,7 +81,7 @@
                             </a>
                     </li>
                     <li class="dashboard-sidenav__board-menu-item">
-                            <a href="#" class="dashboard-sidenav__board-menu-link">
+                            <a href="change-password.html" class="dashboard-sidenav__board-menu-link">
                                 <span class="dashboard-sidenav__board-menu-icon">
                                     <i class="fas fa-unlock-alt"></i>
                                 </span> 


### PR DESCRIPTION
#### What does this PR do?
Add a function that allows a user(Agent) to preview his/her property 

#### Description of Task to be completed?
Carry out the following Tasks 
- Add function in dashboard.js that manages the click event of the preview button on each property
- Modify reference on view-profile.html

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-UI-dashboard-preview-property-166652392 branch and launch view-property.html

#### What are the relevant pivotal tracker stories?
#166652392
