### PR TITLE
#167019605 Add more unit tests for signup

### DIFF
--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -1,7 +1,12 @@
 import request from 'supertest';
 import { expect } from 'chai';
 import app from '../app';
-import user from '../utils/dummy';
+import {
+  validUserData,
+  incompleteUserData,
+  invalidUserData,
+  alreadyExistingUserData
+} from '../utils/dummy';
 
 // Unit Test for Authentication Route
 describe('Auth Route Endpoints', () => {
@@ -9,7 +14,7 @@ describe('Auth Route Endpoints', () => {
     it('should successfully register a user if all required inputs are provided', done => {
       request(app)
         .post('/api/v1/auth/signup')
-        .send(user)
+        .send(validUserData)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(201)
@@ -23,6 +28,48 @@ describe('Auth Route Endpoints', () => {
             'last_name',
             'email'
           );
+        })
+        .end(done);
+    });
+    it('should not signup a user if any or all of the required fields is/are not provided', done => {
+      request(app)
+        .post('/api/v1/auth/signup')
+        .send(incompleteUserData)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Invalid Request');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it('should not signup a user if any of the input parameters is/are invalid', done => {
+      request(app)
+        .post('/api/v1/auth/signup')
+        .send(invalidUserData)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Invalid Request');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it('should not signup a user if he/she provides an already existing email address', done => {
+      request(app)
+        .post('/api/v1/auth/signup')
+        .send(alreadyExistingUserData)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(409)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('409 Conflict');
+          expect(res.body).to.have.all.keys('status', 'error');
         })
         .end(done);
     });

--- a/API/src/utils/dummy.js
+++ b/API/src/utils/dummy.js
@@ -1,13 +1,56 @@
-// Dummy User Object
-const user = {
-  email: 'daylay92@yahoo.com',
-  first_name: 'Ayo',
-  last_name: 'Dele',
-  password: '123we1',
-  confirm_password: '123we1',
-  phoneNumber: '08062490454',
-  address: '23, Andy Street, Ketu',
+import faker from 'faker';
+
+//  valid user data
+const validUserData = {
+  email: faker.internet.email(),
+  first_name: faker.name.firstName(),
+  last_name: faker.name.lastName(),
+  password: faker.internet.password(),
+  confirm_password: faker.internet.password(),
+  phone_number: '08063805512',
+  address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
   gender: 'Male'
 };
 
-export default user;
+//  incomplete user data
+const incompleteUserData = {
+  email: faker.internet.email(),
+  first_name: faker.name.firstName(),
+  last_name: faker.name.lastName(),
+  password: '',
+  confirm_password: '',
+  phone_number: '',
+  address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
+  gender: 'Male'
+};
+
+//  invalid user data
+const invalidUserData = {
+  email: 'cjlfkl',
+  first_name: faker.name.firstName(),
+  last_name: faker.name.lastName(),
+  password: faker.internet.password(),
+  confirm_password: faker.internet.password(),
+  phone_number: 'hjiojojo',
+  address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
+  gender: 'non'
+};
+
+//  already existing user data
+const alreadyExistingUserData = {
+  email: 'zaylay92@yahoo.com',
+  first_name: faker.name.firstName(),
+  last_name: faker.name.lastName(),
+  password: faker.internet.password(),
+  confirm_password: faker.internet.password(),
+  phone_number: '08063805512',
+  address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
+  gender: 'Male'
+};
+
+export {
+  validUserData,
+  incompleteUserData,
+  invalidUserData,
+  alreadyExistingUserData
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,6 +2256,11 @@
         }
       }
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "A server built for a platform where people can create and/or search properties for sale or rent.",
   "main": "./API/lib/app.js",
   "scripts": {
-    "test": "mocha ./API/lib/**/*.test.js --timeout 20000 --exit",
+    "test": "mocha ./API/src/**/*.test.js -r @babel/register --exit true",
     "start": "node ./API/lib/app.js",
     "dev": "nodemon --exec babel-node ./API/src/app.js",
-    "build": "babel ./API/src -d ./API/lib",
-    "test-watch": "npm run build && npm test"
+    "build": "babel ./API/src -d ./API/lib"
   },
   "repository": {
     "type": "git",
@@ -34,6 +33,7 @@
     "@babel/node": "^7.4.5",
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
+    "@babel/register": "^7.4.4",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
@@ -53,6 +53,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "faker": "^4.1.0",
     "jsonwebtoken": "^8.5.1"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Add unit tests that check the following
- Users should not be registered successfully if they submit an email that already exists during signup
- Users should not be registered successfully if they provide invalid parameters during signup
- Users should not be registered successfully if they submit a signup request without providing any or all of the required field data

#### Description of Task to be completed?
Carry out the following Tasks 
- Install @babel/register as a development dependency and modify test command to use @babel/register as an on-the-fly compiler why running 
- Add all unit tests described above
- Install faker, a package that generates dummy data; to facilitate testing

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-API-test-signup-167019605 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167019605 #166945991 #166946123

#### Screenshot
<img width="960" alt="all-sign-test" src="https://user-images.githubusercontent.com/40744698/60473379-bd69c900-9c64-11e9-9f0b-19ab86e5101f.PNG">
