### PR TITLE
#166946295 Add data validation to signup process

### DIFF
--- a/API/src/middlewares/signup-validation.js
+++ b/API/src/middlewares/signup-validation.js
@@ -1,0 +1,121 @@
+import { check, validationResult } from 'express-validator';
+import UserServices from '../services/user';
+
+export default class SignUp {
+  static validate() {
+    return [
+      check(['first_name', 'last_name'])
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isAlpha()
+        .withMessage('Should be Alphabets only')
+        .isLength({ min: 3 })
+        .withMessage('Should be atleast 3 characters long')
+        .trim()
+        .escape(),
+      check('address')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isLength({ min: 5 })
+        .withMessage('Should be atleast 3 characters long')
+        .trim()
+        .escape(),
+      check('email')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .normalizeEmail()
+        .isEmail()
+        .withMessage('Should be a valid Email Address'),
+      check('gender')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isIn(['Male', 'Female'])
+        .withMessage('Should be Male or Female')
+        .trim()
+        .escape(),
+      check('confirm_password')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty'),
+      check('password')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty({ ignore_whitespace: true })
+        .withMessage('Field cannot be empty')
+        .isLength({ min: 6 })
+        .withMessage('Should be atleast 6 characters Long')
+        .custom((value, { req }) => value === req.body.confirm_password)
+        .withMessage('should match the confirm Password field')
+        .trim()
+        .escape(),
+      check('phoneNumber')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isNumeric()
+        .withMessage(
+          'Should be plain numbers without a country code or a + sign'
+        )
+        .isLength({ max: 11, min: 9 })
+        .withMessage('Should be atleast 9-11 characters')
+    ];
+  }
+  /* eslint no-param-reassign: 0 */
+
+  static async verifyValidationResult(req, res, next) {
+    const errors = validationResult(req);
+    let isRequiredError = false;
+    if (!errors.isEmpty()) {
+      const validateErrors = errors.array();
+      const errorObj = validateErrors.reduce((newErrObj, errObj) => {
+        if (errObj.msg === 'Field is Required') isRequiredError = true;
+        if (errObj.msg === 'Field cannot be empty') isRequiredError = true;
+        newErrObj[errObj.param] = !newErrObj[errObj.param]
+          ? errObj.msg
+          : newErrObj[errObj.param];
+        return newErrObj;
+      }, {});
+      if (isRequiredError === true)
+        return res.status(400).json({
+          status: '400 Invalid Request',
+          error: 'Some required fields are missing',
+          errors: errorObj
+        });
+      return res.status(400).json({
+        status: '400 Invalid Request',
+        error: 'Your request contains invalid parameters',
+        errors: errorObj
+      });
+    }
+
+    return next();
+  }
+
+  static async isEmailAlreadyExist(req, res, next) {
+    const { email } = req.body;
+    const user = await UserServices.getUserByEmail(email);
+    if (user)
+      return res.status(409).json({
+        status: '409 Conflict',
+        error: 'A User with this email address already exists'
+      });
+    return next();
+  }
+}

--- a/API/src/routes/auth.js
+++ b/API/src/routes/auth.js
@@ -1,9 +1,16 @@
 import { Router } from 'express';
+import SignUp from '../middlewares/signup-validation';
 import Auth from '../controllers/authController';
 
 const router = Router();
 
 // signup route
-router.post('/signup', Auth.signUp);
+router.post(
+  '/signup',
+  SignUp.validate(),
+  SignUp.verifyValidationResult,
+  SignUp.isEmailAlreadyExist,
+  Auth.signUp
+);
 
 export default router;

--- a/API/src/services/user.js
+++ b/API/src/services/user.js
@@ -88,6 +88,11 @@ class User extends UserModel {
     );
     return token;
   }
+
+  static async getUserByEmail(emailAddress) {
+    const user = users.find(({ email }) => email === emailAddress);
+    return user;
+  }
 }
 
 export default User;

--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -41,7 +41,7 @@ describe('Auth Route Endpoints', () => {
         .expect(res => {
           const { status } = res.body;
           expect(status).to.equal('400 Invalid Request');
-          expect(res.body).to.have.all.keys('status', 'error');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
         })
         .end(done);
     });
@@ -55,7 +55,7 @@ describe('Auth Route Endpoints', () => {
         .expect(res => {
           const { status } = res.body;
           expect(status).to.equal('400 Invalid Request');
-          expect(res.body).to.have.all.keys('status', 'error');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
         })
         .end(done);
     });

--- a/API/src/utils/dummy.js
+++ b/API/src/utils/dummy.js
@@ -3,23 +3,23 @@ import faker from 'faker';
 //  valid user data
 const validUserData = {
   email: faker.internet.email(),
-  first_name: faker.name.firstName(),
-  last_name: faker.name.lastName(),
-  password: faker.internet.password(),
-  confirm_password: faker.internet.password(),
-  phone_number: '08063805512',
+  first_name: 'King',
+  last_name: 'Ayodele',
+  password: 'rrft3456',
+  confirm_password: 'rrft3456',
+  phoneNumber: '08063805512',
   address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
   gender: 'Male'
 };
 
 //  incomplete user data
 const incompleteUserData = {
-  email: faker.internet.email(),
-  first_name: faker.name.firstName(),
-  last_name: faker.name.lastName(),
+  email: '',
+  first_name: 'Eemiy',
+  last_name: 'Kangodan',
   password: '',
   confirm_password: '',
-  phone_number: '',
+  phoneNumber: '',
   address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
   gender: 'Male'
 };
@@ -31,7 +31,7 @@ const invalidUserData = {
   last_name: faker.name.lastName(),
   password: faker.internet.password(),
   confirm_password: faker.internet.password(),
-  phone_number: 'hjiojojo',
+  phoneNumber: 'hjiojojo',
   address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
   gender: 'non'
 };
@@ -39,11 +39,11 @@ const invalidUserData = {
 //  already existing user data
 const alreadyExistingUserData = {
   email: 'zaylay92@yahoo.com',
-  first_name: faker.name.firstName(),
-  last_name: faker.name.lastName(),
-  password: faker.internet.password(),
-  confirm_password: faker.internet.password(),
-  phone_number: '08063805512',
+  first_name: 'Sam',
+  last_name: 'Sung',
+  password: 'King1234',
+  confirm_password: 'King1234',
+  phoneNumber: '08063805512',
   address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
   gender: 'Male'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2153,6 +2153,15 @@
         "vary": "~1.1.2"
       }
     },
+    "express-validator": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.1.1.tgz",
+      "integrity": "sha512-AF6YOhdDiCU7tUOO/OHp2W++I3qpYX7EInMmEEcRGOjs+qoubwgc5s6Wo3OQgxwsWRGCxXlrF73SIDEmY4y3wg==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "validator": "^11.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3710,8 +3719,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -5695,6 +5703,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.0.0.tgz",
+      "integrity": "sha512-+wnGLYqaKV2++nUv60uGzUJyJQwYVOin6pn1tgEiFCeCQO60yeu3Og9/yPccbBX574kxIcEJicogkzx6s6eyag=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "express-validator": "^6.1.1",
     "faker": "^4.1.0",
     "jsonwebtoken": "^8.5.1"
   }


### PR DESCRIPTION
#### What does this PR do?
Add validation middleware to the signup endpoint to verify the authenticity of  request data

#### Description of Task to be completed?
Carry out the following Tasks 
- Create validation middleware 
- Add validation middleware methods to signup route
- Create method to find users by email
- Modify test case to include more paramaters 
- Modify dummy data 

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-signup-validation-166946295 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signup` to test the signup endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Post the data fields in the measure of the use case being tested
- To run unit tests, stop all node processes using `cmd/ctrl + c` and then on run `npm test`
on the command line pallette

#### What are the relevant pivotal tracker stories?
#166946295 #167019605 #166945991 #166946123 #166946650

#### Screenshot
<img width="525" alt="signup-test-passing" src="https://user-images.githubusercontent.com/40744698/60500274-f54b2d80-9cb1-11e9-9e84-3f7f0fbdfdf8.PNG">



