### PR TITLE
#166968834 Add unit tests for login endpoint

### DIFF
--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -5,7 +5,10 @@ import {
   validUserData,
   incompleteUserData,
   invalidUserData,
-  alreadyExistingUserData
+  alreadyExistingUserData,
+  validLoginCredentials,
+  invalidLoginCredentials,
+  incompleteLoginCredentials
 } from '../utils/dummy';
 
 // Unit Test for Authentication Route
@@ -69,6 +72,57 @@ describe('Auth Route Endpoints', () => {
         .expect(res => {
           const { status } = res.body;
           expect(status).to.equal('409 Conflict');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+  });
+  //    tests for login
+  describe('POST api/v1/auth/signin', () => {
+    it('should successfully login a user if user provides valid login credentials', done => {
+      request(app)
+        .post('/api/v1/auth/signin')
+        .send(validLoginCredentials)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const { status, data } = res.body;
+          expect(status).to.equal('Success');
+          expect(data).to.have.all.keys(
+            'token',
+            'id',
+            'first_name',
+            'last_name',
+            'email'
+          );
+        })
+        .end(done);
+    });
+    it('should prevent user from logging in if any or all of the login credentials is/are not provided', done => {
+      request(app)
+        .post('/api/v1/auth/signin')
+        .send(incompleteLoginCredentials)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it('should prevent a user from logging in with invalid login credentials', done => {
+      request(app)
+        .post('/api/v1/auth/signin')
+        .send(invalidLoginCredentials)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('401 Unauthorized');
           expect(res.body).to.have.all.keys('status', 'error');
         })
         .end(done);

--- a/API/src/utils/dummy.js
+++ b/API/src/utils/dummy.js
@@ -1,5 +1,6 @@
 import faker from 'faker';
 
+// signup data
 //  valid user data
 const validUserData = {
   email: faker.internet.email(),
@@ -48,9 +49,29 @@ const alreadyExistingUserData = {
   gender: 'Male'
 };
 
+// login credentials
+// Valid credentials
+const validLoginCredentials = {
+  email: 'zaylay92@yahoo.com',
+  password: 'ayo1234'
+};
+// Invalid credentials
+const invalidLoginCredentials = {
+  email: 'desk@yahoo.com',
+  password: 'ayo1234'
+};
+// Invalid credentials
+const incompleteLoginCredentials = {
+  email: 'zaylay92@yahoo.com',
+  password: ''
+};
+
 export {
   validUserData,
   incompleteUserData,
   invalidUserData,
-  alreadyExistingUserData
+  alreadyExistingUserData,
+  validLoginCredentials,
+  invalidLoginCredentials,
+  incompleteLoginCredentials
 };


### PR DESCRIPTION
#### What does this PR do?
Add unit tests to the login endpoint that checks the following scenarios;
- A User should be logged in successfully if they provide valid credentials
- A User should not be logged in if they provide invalid credentials
- A User should not be logged in if any of the fields are empty

#### Description of Task to be completed?
Carry out the following Tasks 
- Write unit tests as described above
- Create dummy data to facilitate testing

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-API-login-tests-166968834 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#166968834, #166967936, #166968018

#### Screenshot

<img width="596" alt="login-test-fail" src="https://user-images.githubusercontent.com/40744698/60510687-ee2f1a00-9cc7-11e9-8e83-cb551c1093ff.PNG">
