### PR TITLE
#167058677 Add unit tests for the post property endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,6 @@
     },
     "rules": {
         "prettier/prettier": "error",
-        "no-console" : 0,
         "mocha/no-exclusive-tests": "error"
     }
 }

--- a/API/src/app.js
+++ b/API/src/app.js
@@ -42,7 +42,7 @@ app.all('*', (req, res) =>
     .status(404)
     .json({ status: '404 Not Found', message: "This route doesn't exist" })
 );
-
+/* eslint no-console : 0 */
 // Listen for Requests to Server
 app.listen(port, () =>
   console.log(`Amazing stuff is happening on port: ${app.get('port')}`)

--- a/API/src/controllers/authController.js
+++ b/API/src/controllers/authController.js
@@ -27,24 +27,17 @@ class Auth {
         pass,
         phoneNumber
       );
-      const isSaved = user.save();
-      if (isSaved) {
-        const token = user.generateToken();
-        return res.status(201).json({
-          status: 'Success',
-          data: {
-            token,
-            id,
-            first_name,
-            last_name,
-            email
-          }
-        });
-      }
-      return res.status(500).json({
-        status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+      await user.save();
+      const token = user.generateToken();
+      return res.status(201).json({
+        status: 'Success',
+        data: {
+          token,
+          id,
+          first_name,
+          last_name,
+          email
+        }
       });
     } catch (e) {
       return res.status(500).json({

--- a/API/src/middlewares/signup-validation.js
+++ b/API/src/middlewares/signup-validation.js
@@ -92,7 +92,7 @@ export default class SignUp {
           : newErrObj[errObj.param];
         return newErrObj;
       }, {});
-      if (isRequiredError === true)
+      if (isRequiredError)
         return res.status(400).json({
           status: '400 Invalid Request',
           error: 'Some required fields are missing',

--- a/API/src/services/user.js
+++ b/API/src/services/user.js
@@ -50,7 +50,7 @@ class User extends UserModel {
   }
 
   /* eslint camelcase: 0 */
-  save() {
+  async save() {
     const currentNoOfUsers = users.length;
     const {
       id,
@@ -74,7 +74,12 @@ class User extends UserModel {
       gender,
       is_admin
     });
-    return newNoOfUsers > currentNoOfUsers;
+    const isSaved =
+      newNoOfUsers > currentNoOfUsers
+        ? true
+        : new Error('User was not Created');
+    if (isSaved) return true;
+    throw isSaved;
   }
 
   generateToken() {

--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -1,4 +1,4 @@
-import request from 'supertest';
+import supertest from 'supertest';
 import { expect } from 'chai';
 import app from '../app';
 import {
@@ -11,11 +11,13 @@ import {
   incompleteLoginCredentials
 } from '../utils/dummy';
 
+const request = supertest(app);
+
 // Unit Test for Authentication Route
 describe('Auth Route Endpoints', () => {
   describe('POST api/v1/auth/signup', () => {
     it('should successfully register a user if all required inputs are provided', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signup')
         .send(validUserData)
         .set('Accept', 'application/json')
@@ -35,7 +37,7 @@ describe('Auth Route Endpoints', () => {
         .end(done);
     });
     it('should not signup a user if any or all of the required fields is/are not provided', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signup')
         .send(incompleteUserData)
         .set('Accept', 'application/json')
@@ -49,7 +51,7 @@ describe('Auth Route Endpoints', () => {
         .end(done);
     });
     it('should not signup a user if any of the input parameters is/are invalid', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signup')
         .send(invalidUserData)
         .set('Accept', 'application/json')
@@ -63,7 +65,7 @@ describe('Auth Route Endpoints', () => {
         .end(done);
     });
     it('should not signup a user if he/she provides an already existing email address', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signup')
         .send(alreadyExistingUserData)
         .set('Accept', 'application/json')
@@ -80,7 +82,7 @@ describe('Auth Route Endpoints', () => {
   //    tests for login
   describe('POST api/v1/auth/signin', () => {
     it('should successfully login a user if user provides valid login credentials', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signin')
         .send(validLoginCredentials)
         .set('Accept', 'application/json')
@@ -100,7 +102,7 @@ describe('Auth Route Endpoints', () => {
         .end(done);
     });
     it('should prevent user from logging in if any or all of the login credentials is/are not provided', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signin')
         .send(incompleteLoginCredentials)
         .set('Accept', 'application/json')
@@ -114,7 +116,7 @@ describe('Auth Route Endpoints', () => {
         .end(done);
     });
     it('should prevent a user from logging in with invalid login credentials', done => {
-      request(app)
+      request
         .post('/api/v1/auth/signin')
         .send(invalidLoginCredentials)
         .set('Accept', 'application/json')
@@ -129,3 +131,5 @@ describe('Auth Route Endpoints', () => {
     });
   });
 });
+
+export default request;

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -1,0 +1,144 @@
+import { expect } from 'chai';
+import path from 'path';
+import request from './auth.test';
+import { validToken, inValidToken } from '../utils/dummy';
+
+describe('Property Route Endpoints', () => {
+  describe('POST api/v1/property', () => {
+    it('should allow a authenticated user(Agent) to successfully post a property advert if he/she provides all the required data', done => {
+      request
+        .post('/api/v1/property')
+        .field('status', 'Available')
+        .field('price', 80000.0)
+        .field('state', 'Lagos')
+        .field('city', 'Ikeja')
+        .field('address', '30, Caleb Road')
+        .field('type', '2 bedroom')
+        .field('purpose', 'For Rent')
+        .attach(
+          'image',
+          path.resolve(__dirname, '../../../UI/assets/images/1.jpg')
+        )
+        .set('x-access-token', validToken)
+        .set('Connection', 'keep-alive')
+        .expect('Content-Type', /json/)
+        .expect(201)
+        .expect(res => {
+          const { status, data } = res.body;
+          expect(status).to.equal('Success');
+          expect(data).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'purpose'
+          );
+        })
+        .end(done);
+    });
+    it('should prevent an unathenticated user from posting a property advert', done => {
+      request
+        .post('/api/v1/property')
+        .field('status', 'Available')
+        .field('price', 80000.0)
+        .field('state', 'Lagos')
+        .field('city', 'Ikeja')
+        .field('address', '30, Caleb Road')
+        .field('type', '2 bedroom')
+        .field('purpose', 'For Rent')
+        .attach(
+          'image',
+          path.resolve(__dirname, '../../../UI/assets/images/1.jpg')
+        )
+        .set('Connection', 'keep-alive')
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Required');
+        })
+        .end(done);
+    });
+    it('should prevent a user with an Invalid token from posting a property advert', done => {
+      request
+        .post('/api/v1/property')
+        .field('status', 'Available')
+        .field('price', 80000.0)
+        .field('state', 'Lagos')
+        .field('city', 'Ikeja')
+        .field('address', '30, Caleb Road')
+        .field('type', '2 bedroom')
+        .field('purpose', 'For Rent')
+        .attach(
+          'image',
+          path.resolve(__dirname, '../../../UI/assets/images/1.jpg')
+        )
+        .set('Connection', 'keep-alive')
+        .set('x-access-token', inValidToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Required');
+        })
+        .end(done);
+    });
+    it('should prevent a user from posting a property advert if he/she provides invalid input parameters', done => {
+      request
+        .post('/api/v1/property')
+        .field('status', 'Available')
+        .field('price', 'rhjfioo')
+        .field('state', 'Lagos')
+        .field('city', 12344)
+        .field('address', '30, Caleb Road')
+        .field('type', '2 bedroom')
+        .field('purpose', 'For Rent')
+        .attach(
+          'image',
+          path.resolve(__dirname, '../../../UI/assets/images/1.jpg')
+        )
+        .set('Connection', 'keep-alive')
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Bad Request');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
+        })
+        .end(done);
+    });
+    it('should prevent a user from posting an advert if any/all the required input parameters is/are not provided or is/are provided as empty fields', done => {
+      request
+        .post('/api/v1/property')
+        .field('status', 'Available')
+        .field('price', '')
+        .field('state', 'Lagos')
+        .field('city', 'Ikeja')
+        .field('address', '')
+        .field('type', '2 bedroom')
+        .field('purpose', 'For Rent')
+        .attach(
+          'image',
+          path.resolve(__dirname, '../../../UI/assets/images/1.jpg')
+        )
+        .set('Connection', 'keep-alive')
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Bad Request');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
+        })
+        .end(done);
+    });
+  });
+});

--- a/API/src/utils/dummy.js
+++ b/API/src/utils/dummy.js
@@ -1,4 +1,5 @@
 import faker from 'faker';
+import UserServices from '../services/user';
 
 // signup data
 //  valid user data
@@ -66,6 +67,21 @@ const incompleteLoginCredentials = {
   password: ''
 };
 
+// Property Test Data
+// Valid Token
+const validToken = UserServices.generateToken(490, false);
+const inValidToken = 'eyJhbGciOiJI.UzI1NiIsInR5c.CI6IkpXVCJ9';
+const validPropertyData = {
+  status: 'Available',
+  price: 800000.0,
+  state: 'Lagos',
+  city: 'Ikeja',
+  address: '30, Caleb Road',
+  type: '2 bedroom',
+  image_url: '',
+  purpose: 'For Rent'
+};
+
 export {
   validUserData,
   incompleteUserData,
@@ -73,5 +89,8 @@ export {
   alreadyExistingUserData,
   validLoginCredentials,
   invalidLoginCredentials,
-  incompleteLoginCredentials
+  incompleteLoginCredentials,
+  validToken,
+  validPropertyData,
+  inValidToken
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A server built for a platform where people can create and/or search properties for sale or rent.",
   "main": "./API/lib/app.js",
   "scripts": {
-    "test": "mocha ./API/src/**/*.test.js -r @babel/register --exit true",
+    "test": "mocha ./API/src/**/*.test.js -r @babel/register --timeout 30000 --exit true",
     "start": "node ./API/lib/app.js",
     "dev": "nodemon --exec babel-node ./API/src/app.js",
     "build": "babel ./API/src -d ./API/lib"


### PR DESCRIPTION
#### What does this PR do?
Add unit tests  for the API endpoint that enables users to post a property advert(`/api/v1/property`) which checks the following:
- The app should prevent a user who has not been authenticated from posting a property advert
- The app should prevent a user from posting an advert if he/she provides an invalid token in the request header
- The app should prevent an authenticated user from posting a property advert if he/she provides invalid input parameters in the body of the request
- The app should prevent an authenticated user from posting a property advert if he/she provides empty fields or doesn't provide all the required field parameters

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify existing test script
- Create test script that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-post-property-test-167058677 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167058677 #167066640 #167065132 #167064249 #167063905 

#### Screenshot
<img width="828" alt="failing-test-post" src="https://user-images.githubusercontent.com/40744698/60634978-df03b580-9e08-11e9-877c-ca84c7842658.PNG">

