### PR TITLE
#167067043 Add post property endpoint

### DIFF
--- a/API/src/app.js
+++ b/API/src/app.js
@@ -3,6 +3,7 @@ import express from 'express';
 import { urlencoded, json } from 'body-parser';
 import cors from 'cors';
 import authRoutes from './routes/auth';
+import propertyRoutes from './routes/property';
 
 // Initialize process.env variables for the .env file
 config();
@@ -27,6 +28,7 @@ app.use(json());
 
 // Main Routes
 app.use('/api/v1/auth', authRoutes);
+app.use('/api/v1/property', propertyRoutes);
 
 // Default Route
 app.get('/api/v1', (req, res) =>

--- a/API/src/controllers/authController.js
+++ b/API/src/controllers/authController.js
@@ -64,7 +64,7 @@ class Auth {
           error: 'Incorrect Password'
         });
       const { id, first_name, last_name } = user;
-      const token = User.generateToken();
+      const token = User.generateToken(id, false);
       return res.status(200).json({
         status: 'Success',
         data: {

--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -1,0 +1,54 @@
+import Helpers from '../utils/helpers';
+import properties from '../data/data-structure/properties';
+import Property from '../services/property';
+
+export default class PropertyController {
+  /* eslint camelcase: 0 */
+  static async postProperty(req, res) {
+    try {
+      const { price, state, city, address, type, purpose } = req.body;
+      let { status } = req.body;
+      const owner = req.auth.id;
+      const { url, originalname } = req.imageContent;
+      const id = await Helpers.createId(properties);
+      status = !status ? 'Available' : status;
+      const property = new Property(
+        id,
+        owner,
+        price,
+        state,
+        city,
+        address,
+        type,
+        originalname,
+        url,
+        purpose,
+        status
+      );
+      const { created_on } = property;
+      await property.save();
+      return res.status(201).json({
+        status: 'Success',
+        data: {
+          id,
+          status,
+          type,
+          state,
+          city,
+          address,
+          price,
+          created_on,
+          image_url: url,
+          imageName: originalname,
+          purpose
+        }
+      });
+    } catch (err) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
+}

--- a/API/src/data/data-structure/properties.js
+++ b/API/src/data/data-structure/properties.js
@@ -1,0 +1,31 @@
+import faker from 'faker';
+
+const properties = [
+  {
+    id: 1,
+    owner: 1,
+    price: 600000.0,
+    state: 'Lagos',
+    city: 'Ojota',
+    address: '20, Ojuka Street',
+    type: 'Studio Flat',
+    image_url: faker.image.imageUrl(),
+    purpose: 'For Rent',
+    status: 'Available',
+    created_on: new Date().toLocaleString()
+  },
+  {
+    id: 2,
+    owner: 2,
+    price: 700000.0,
+    state: 'Ondo',
+    city: 'Akure',
+    address: '20, Donga Street',
+    type: 'Mini Flat',
+    image_url: faker.image.imageUrl(),
+    purpose: 'For Rent',
+    status: 'Available',
+    created_on: new Date().toLocaleString()
+  }
+];
+export default properties;

--- a/API/src/middlewares/authenticate.js
+++ b/API/src/middlewares/authenticate.js
@@ -1,0 +1,28 @@
+import jwt from 'jsonwebtoken';
+import { config } from 'dotenv';
+
+config();
+
+export default class Authenticate {
+  static async verify(req, res, next) {
+    const token = req.headers['x-access-token'];
+    if (!token) {
+      res.status(401).json({
+        status: '401 Unauthorized',
+        error: 'Access token is Required'
+      });
+      return;
+    }
+
+    jwt.verify(token, process.env.SIGN_SECRET, (err, decoded) => {
+      if (err)
+        return res.status(401).json({
+          status: '401 Unauthorized',
+          error: 'Access token is Invalid'
+        });
+      const { data } = decoded;
+      req.auth = { ...data };
+      return next();
+    });
+  }
+}

--- a/API/src/middlewares/image-upload.js
+++ b/API/src/middlewares/image-upload.js
@@ -1,0 +1,27 @@
+import multer from 'multer';
+import storage from '../utils/cloudinary';
+
+export default class ImageUpload {
+  static multerUploader(req, res, next) {
+    const multerUpload = multer({
+      storage,
+      limits: { files: 1, fileSize: 750000 }
+    }).single('image');
+    multerUpload(req, res, err => {
+      if (err instanceof multer.MulterError)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'Image should not exceed 750kb'
+        });
+
+      if (err)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'Invalid File Format'
+        });
+      const { url, originalname } = req.file;
+      req.imageContent = { url, originalname };
+      return next();
+    });
+  }
+}

--- a/API/src/models/propertyModel.js
+++ b/API/src/models/propertyModel.js
@@ -1,0 +1,28 @@
+export default class Property {
+  constructor(
+    id,
+    owner,
+    price,
+    state,
+    city,
+    address,
+    type,
+    imageName,
+    imageUrl,
+    purpose,
+    status = 'Available'
+  ) {
+    this.id = id;
+    this.owner = owner;
+    this.status = status;
+    this.price = price;
+    this.state = state;
+    this.city = city;
+    this.address = address;
+    this.type = type;
+    this.imageName = imageName;
+    this.image_url = imageUrl;
+    this.purpose = purpose;
+    this.created_on = new Date().toLocaleString();
+  }
+}

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import propertyController from '../controllers/propertyController';
+import ImageUpload from '../middlewares/image-upload';
+import Authenticate from '../middlewares/authenticate';
+
+const router = Router();
+
+router.post(
+  '/',
+  Authenticate.verify,
+  ImageUpload.multerUploader,
+  propertyController.postProperty
+);
+
+export default router;

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -1,0 +1,69 @@
+import PropertyModel from '../models/propertyModel';
+import properties from '../data/data-structure/properties';
+
+export default class Property extends PropertyModel {
+  constructor(
+    id = null,
+    owner,
+    price,
+    state,
+    city,
+    address,
+    type,
+    imageName,
+    imageUrl,
+    purpose,
+    status
+  ) {
+    super(
+      id,
+      owner,
+      price,
+      state,
+      city,
+      address,
+      type,
+      imageName,
+      imageUrl,
+      purpose,
+      status
+    );
+  }
+
+  /* eslint camelcase : 0 */
+  async save() {
+    const oldLength = properties.length;
+    const {
+      id,
+      owner,
+      price,
+      state,
+      city,
+      address,
+      type,
+      imageName,
+      image_url,
+      purpose,
+      status,
+      created_on
+    } = this;
+    const newLength = properties.push({
+      id,
+      owner,
+      price,
+      state,
+      city,
+      address,
+      type,
+      imageName,
+      image_url,
+      purpose,
+      status,
+      created_on
+    });
+    const isSaved =
+      newLength > oldLength ? true : new Error('Property was not saved');
+    if (isSaved) return isSaved;
+    throw isSaved;
+  }
+}

--- a/API/src/services/user.js
+++ b/API/src/services/user.js
@@ -78,7 +78,7 @@ class User extends UserModel {
       newNoOfUsers > currentNoOfUsers
         ? true
         : new Error('User was not Created');
-    if (isSaved) return true;
+    if (isSaved) return isSaved;
     throw isSaved;
   }
 

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -36,7 +36,8 @@ describe('Property Route Endpoints', () => {
             'price',
             'created_on',
             'image_url',
-            'purpose'
+            'purpose',
+            'imageName'
           );
         })
         .end(done);
@@ -86,7 +87,7 @@ describe('Property Route Endpoints', () => {
         .expect(res => {
           const { status, error } = res.body;
           expect(status).to.equal('401 Unauthorized');
-          expect(error).to.equal('Access token is Required');
+          expect(error).to.equal('Access token is Invalid');
         })
         .end(done);
     });

--- a/API/src/utils/cloudinary.js
+++ b/API/src/utils/cloudinary.js
@@ -1,0 +1,28 @@
+import { config } from 'dotenv';
+import cloudinary from 'cloudinary';
+import cloudinaryStorage from 'multer-storage-cloudinary';
+
+config();
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+// configure cloud storage
+const storage = cloudinaryStorage({
+  cloudinary,
+  allowedFormats: ['jpg', 'png'],
+  format: 'png',
+  folder: 'samples/test',
+  transformation: [
+    { if: 'w_lt_370_or_h_lt_295' },
+    { effect: 'sharpen', width: 300, height: 295, crop: 'scale' },
+    { if: 'else' },
+    { effect: 'sharpen' },
+    { if: 'end' }
+  ]
+});
+
+export default storage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,6 +961,11 @@
         }
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1232,8 +1237,39 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -1387,6 +1423,15 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "cloudinary": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.14.0.tgz",
+      "integrity": "sha512-auJY4aD1UGnQTD2iy6kuTA+FJsqyrr9svG12WYSPAO6oRGRf+16UFDDBNuRMm37wj8Tyn8LyiED0b+Jha36ORA==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "q": "^1.5.1"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1448,6 +1493,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -1677,6 +1733,38 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "diff": {
       "version": "3.5.0",
@@ -4032,6 +4120,29 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
+      "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
+    },
+    "multer-storage-cloudinary": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/multer-storage-cloudinary/-/multer-storage-cloudinary-2.2.1.tgz",
+      "integrity": "sha1-0x8luPCVID8xyeVUwBrYxpGxqXQ=",
+      "requires": {
+        "run-parallel": "^1.1.6"
+      }
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -4623,6 +4734,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -4932,6 +5048,11 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "rxjs": {
       "version": "6.5.2",
@@ -5302,6 +5423,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5562,6 +5688,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -5803,6 +5934,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,14 @@
     "@babel/runtime": "^7.4.5",
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
+    "cloudinary": "^1.14.0",
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
     "express-validator": "^6.1.1",
     "faker": "^4.1.0",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "multer": "^1.4.1",
+    "multer-storage-cloudinary": "^2.2.1"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Add an endpoint to enable a user who is logged in to post a property advert 
#### Description of Task to be completed?
Carry out the following Tasks 
- Create property Model, property services, property controller and a property route to manage the posting of properties advert on the App
- Add `/api/v1/property`  endpoint
- Implement a middleware to verify that a user's token is valid before he/she can post a property advert
- Implement a middleware to handle image upload to cloudinary via `multer` and `multer-cloudinary-storage`

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-post-property-167067043 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signup` to test the signup endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Post the data fields described in the entity specification for a property in the requirement

#### Any background context you want to provide?
 The data fields necessary for the request should be as specified in the requirement

#### What are the relevant pivotal tracker stories?
#167067043

#### Screenshot
<img width="948" alt="post-property-success" src="https://user-images.githubusercontent.com/40744698/60678506-9e458400-9e7c-11e9-87ed-d3b7995e9c18.PNG">
<img width="834" alt="test-result-after-post" src="https://user-images.githubusercontent.com/40744698/60678508-9ede1a80-9e7c-11e9-9dba-435417372cff.PNG">