### PR TITLE
#167067357 Add data validation to post property process

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -7,10 +7,12 @@ export default class PropertyController {
   static async postProperty(req, res) {
     try {
       const { price, state, city, address, type, purpose } = req.body;
-      let { status } = req.body;
       const owner = req.auth.id;
-      const { url, originalname } = req.imageContent;
+      const { url, originalname } = req.file;
       const id = await Helpers.createId(properties);
+      let { status } = req.body;
+      let { otherType } = req.body;
+      otherType = !otherType ? null : otherType;
       status = !status ? 'Available' : status;
       const property = new Property(
         id,
@@ -23,7 +25,8 @@ export default class PropertyController {
         originalname,
         url,
         purpose,
-        status
+        status,
+        otherType
       );
       const { created_on } = property;
       await property.save();
@@ -40,7 +43,8 @@ export default class PropertyController {
           created_on,
           image_url: url,
           imageName: originalname,
-          purpose
+          purpose,
+          otherType
         }
       });
     } catch (err) {

--- a/API/src/data/data-structure/properties.js
+++ b/API/src/data/data-structure/properties.js
@@ -12,7 +12,8 @@ const properties = [
     image_url: faker.image.imageUrl(),
     purpose: 'For Rent',
     status: 'Available',
-    created_on: new Date().toLocaleString()
+    created_on: new Date().toLocaleString(),
+    other_type: null
   },
   {
     id: 2,
@@ -25,7 +26,8 @@ const properties = [
     image_url: faker.image.imageUrl(),
     purpose: 'For Rent',
     status: 'Available',
-    created_on: new Date().toLocaleString()
+    created_on: new Date().toLocaleString(),
+    other_type: null
   }
 ];
 export default properties;

--- a/API/src/middlewares/image-upload.js
+++ b/API/src/middlewares/image-upload.js
@@ -1,5 +1,5 @@
 import multer from 'multer';
-import storage from '../utils/cloudinary';
+import { storage } from '../utils/cloudinary';
 
 export default class ImageUpload {
   static multerUploader(req, res, next) {
@@ -19,8 +19,11 @@ export default class ImageUpload {
           status: '400 Bad Request',
           error: 'Invalid File Format'
         });
-      const { url, originalname } = req.file;
-      req.imageContent = { url, originalname };
+      if (!req.file)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'An Image is Required'
+        });
       return next();
     });
   }

--- a/API/src/middlewares/post-property-validation.js
+++ b/API/src/middlewares/post-property-validation.js
@@ -1,0 +1,127 @@
+import { check, validationResult } from 'express-validator';
+import { states, type, purpose, status } from '../utils/validation-data';
+import { deleteImage } from '../utils/cloudinary';
+
+export default class PostProperty {
+  static validate() {
+    return [
+      check('status')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isIn([...status])
+        .withMessage('should be either Available, Sold or Rented')
+        .trim(),
+      check('price')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isLength({ min: 3, max: 15 })
+        .withMessage('should be between 3-15 characters long')
+        .trim()
+        .matches(/^\d+(\.|\d)[0-9]$/)
+        .withMessage('should be a float or numbers')
+        .escape(),
+      check('state')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isIn([...states])
+        .withMessage('should be one of the states listed')
+        .trim(),
+      check('city')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isAlpha()
+        .withMessage('Should be Alphabets only')
+        .trim()
+        .isLength({ min: 3 })
+        .withMessage('Should be atleast 3 characters long')
+        .escape(),
+      check('address')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isLength({ min: 5 })
+        .withMessage('Should be atleast 3 characters long')
+        .trim()
+        .escape(),
+      check('type')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isIn([...type])
+        .withMessage('should be one of the types listed'),
+      check('otherType')
+        .custom((value, { req }) => {
+          if (!value) return req.body.type.trim() !== 'Others';
+          return true;
+        })
+        .withMessage('should only be used when the selected type is Others')
+        .custom((value, { req }) => {
+          if (value) return req.body.type.trim() === 'Others';
+          return true;
+        })
+        .withMessage('should only be used when the selected type is Others')
+        .custom(value => {
+          if (value) return value.trim().length > 3 && value.trim().length < 13;
+          return true;
+        })
+        .withMessage('Should be between 3-12 characters long')
+        .trim()
+        .escape(),
+      check('purpose')
+        .exists()
+        .withMessage('Field is Required')
+        .not()
+        .isEmpty()
+        .withMessage('Field cannot be empty')
+        .isIn([...purpose])
+        .withMessage('should be one of the types listed')
+    ];
+  }
+  /* eslint no-param-reassign: 0 */
+
+  static async verifyValidationResult(req, res, next) {
+    const errors = validationResult(req);
+    let isRequiredError = false;
+    if (!errors.isEmpty()) {
+      const validateErrors = errors.array();
+      const errorObj = validateErrors.reduce((newErrObj, errObj) => {
+        if (errObj.msg === 'Field is Required') isRequiredError = true;
+        if (errObj.msg === 'Field cannot be empty') isRequiredError = true;
+        newErrObj[errObj.param] = !newErrObj[errObj.param]
+          ? errObj.msg
+          : newErrObj[errObj.param];
+        return newErrObj;
+      }, {});
+      deleteImage(req.file.public_id);
+      if (isRequiredError)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'Some required fields are missing',
+          errors: errorObj
+        });
+      return res.status(400).json({
+        status: '400 Bad Request',
+        error: 'Your request contains invalid parameters',
+        errors: errorObj
+      });
+    }
+
+    return next();
+  }
+}

--- a/API/src/models/propertyModel.js
+++ b/API/src/models/propertyModel.js
@@ -10,7 +10,8 @@ export default class Property {
     imageName,
     imageUrl,
     purpose,
-    status = 'Available'
+    status,
+    otherType
   ) {
     this.id = id;
     this.owner = owner;
@@ -24,5 +25,6 @@ export default class Property {
     this.image_url = imageUrl;
     this.purpose = purpose;
     this.created_on = new Date().toLocaleString();
+    this.otherType = otherType;
   }
 }

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -2,13 +2,16 @@ import { Router } from 'express';
 import propertyController from '../controllers/propertyController';
 import ImageUpload from '../middlewares/image-upload';
 import Authenticate from '../middlewares/authenticate';
+import PostProperty from '../middlewares/post-property-validation';
 
 const router = Router();
 
 router.post(
   '/',
-  Authenticate.verify,
   ImageUpload.multerUploader,
+  Authenticate.verify,
+  PostProperty.validate(),
+  PostProperty.verifyValidationResult,
   propertyController.postProperty
 );
 

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -13,7 +13,8 @@ export default class Property extends PropertyModel {
     imageName,
     imageUrl,
     purpose,
-    status
+    status = 'Available',
+    otherType = null
   ) {
     super(
       id,
@@ -26,7 +27,8 @@ export default class Property extends PropertyModel {
       imageName,
       imageUrl,
       purpose,
-      status
+      status,
+      otherType
     );
   }
 

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -9,11 +9,11 @@ describe('Property Route Endpoints', () => {
       request
         .post('/api/v1/property')
         .field('status', 'Available')
-        .field('price', 80000.0)
+        .field('price', 800000)
         .field('state', 'Lagos')
         .field('city', 'Ikeja')
         .field('address', '30, Caleb Road')
-        .field('type', '2 bedroom')
+        .field('type', 'Mini Flat')
         .field('purpose', 'For Rent')
         .attach(
           'image',
@@ -37,7 +37,8 @@ describe('Property Route Endpoints', () => {
             'created_on',
             'image_url',
             'purpose',
-            'imageName'
+            'imageName',
+            'otherType'
           );
         })
         .end(done);
@@ -108,7 +109,7 @@ describe('Property Route Endpoints', () => {
         .set('Connection', 'keep-alive')
         .set('x-access-token', validToken)
         .expect('Content-Type', /json/)
-        .expect(401)
+        .expect(400)
         .expect(res => {
           const { status } = res.body;
           expect(status).to.equal('400 Bad Request');
@@ -133,7 +134,7 @@ describe('Property Route Endpoints', () => {
         .set('Connection', 'keep-alive')
         .set('x-access-token', validToken)
         .expect('Content-Type', /json/)
-        .expect(401)
+        .expect(400)
         .expect(res => {
           const { status } = res.body;
           expect(status).to.equal('400 Bad Request');

--- a/API/src/utils/cloudinary.js
+++ b/API/src/utils/cloudinary.js
@@ -24,5 +24,8 @@ const storage = cloudinaryStorage({
     { if: 'end' }
   ]
 });
+const deleteImage = publicId => {
+  cloudinary.uploader.destroy(publicId);
+};
 
-export default storage;
+export { storage, deleteImage };

--- a/API/src/utils/validation-data.js
+++ b/API/src/utils/validation-data.js
@@ -1,0 +1,57 @@
+const states = [
+  'Abia',
+  'Adamawa',
+  'Anambra',
+  'Akwa Ibom',
+  'Bauchi',
+  'Bayelsa',
+  'Benue',
+  'Borno',
+  'Cross River',
+  'Delta',
+  'Ebonyi',
+  'Enugu',
+  'Edo',
+  'Ekiti',
+  'FCT - Abuja',
+  'Gombe',
+  'Imo',
+  'Jigawa',
+  'Kaduna',
+  'Kano',
+  'Katsina',
+  'Kebbi',
+  'Kogi',
+  'Kwara',
+  'Lagos',
+  'Nasarawa',
+  'Niger',
+  'Ogun',
+  'Ondo',
+  'Osun',
+  'Oyo',
+  'Plateau',
+  'Rivers',
+  'Sokoto',
+  'Taraba',
+  'Yobe',
+  'Zamfara'
+];
+
+const type = [
+  'Studio Flat',
+  'Mini Flat',
+  '2 Bedroom',
+  '3 Bedroom',
+  'Duplex',
+  'Twin Duplex',
+  'Office Apartment',
+  'Land',
+  'Others'
+];
+
+const status = ['Available', 'Sold', 'Rented'];
+
+const purpose = ['For Rent', 'For Sale'];
+
+export { type, states, status, purpose };


### PR DESCRIPTION
#### What does this PR do?
Add data validation to the `/api/v1/property` endpoint 

#### Description of Task to be completed?
Carry out the following Tasks 
- Add validation middleware 
- Modify the error handling implementation in the `image-upload middeware`
- Modify the `property model` to contain more fields
- Add validation default data
- Add a `deleteImage` function that would ensure an uploaded image is deleted from the cloud if the form data fields which only become available after the image has been uploaded fails validation

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-validate-post-property-167067357 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167067357 #167058677 #167066640 #167065132 #167064249 #167063905 

#### Screenshot
<img width="877" alt="post-data-validation" src="https://user-images.githubusercontent.com/40744698/60717008-ac48e280-9f18-11e9-91db-a0843ba64cd2.PNG">


