### PR TITLE
#167106396 Add authorization to update property endpoint

### DIFF
--- a/API/src/middlewares/authorize.js
+++ b/API/src/middlewares/authorize.js
@@ -1,0 +1,30 @@
+import properties from '../data/data-structure/properties';
+/* eslint camelcase: 0 */
+const authorize = (req, res, next) => {
+  try {
+    const propId = req.params.id;
+    const { is_admin } = req.auth;
+    if (is_admin) return next();
+    const requesterId = req.auth.id;
+    const property = properties.find(prop => prop.id === parseInt(propId, 10));
+    if (!property)
+      return res.status(404).json({
+        status: '404 Not Found',
+        error: "The property you requested to update doesn't exist"
+      });
+    const { owner } = property;
+    if (requesterId !== owner)
+      return res.status(403).json({
+        status: '403 Forbidden Request',
+        error: 'You have to be an Admin to perform this action'
+      });
+    return next();
+  } catch (e) {
+    return res.status(500).json({
+      status: '500 Server Interval Error',
+      error: 'Something went wrong while processing your request, Do try again'
+    });
+  }
+};
+
+export default authorize;

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -3,16 +3,23 @@ import propertyController from '../controllers/propertyController';
 import ImageUpload from '../middlewares/image-upload';
 import Authenticate from '../middlewares/authenticate';
 import PostProperty from '../middlewares/post-property-validation';
+import authorize from '../middlewares/authorize';
 
 const router = Router();
 
 router.post(
   '/',
-  ImageUpload.multerUploader,
   Authenticate.verify,
+  ImageUpload.multerUploader,
   PostProperty.validate(),
   PostProperty.verifyValidationResult,
   propertyController.postProperty
+);
+router.patch(
+  '/:id',
+  Authenticate.verify,
+  authorize,
+  ImageUpload.multerUploader
 );
 
 export default router;

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -266,7 +266,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent any user except an Admin from updating a property advert posted by another user', done => {
       request
-        .patch('/api/v1/property/2')
+        .patch('/api/v1/property/1')
         .field('status', 'Available')
         .field('state', 'Lagos')
         .field('purpose', 'For Rent')


### PR DESCRIPTION
#### What does this PR do?
Add access control to prevent any user except an admin from updating a property advert when a  patch request is made to the `/api/v1/property/:id` endpoint

#### Description of Task to be completed?
Carry out the following Tasks 
- Create a middleware to perform authorization
- Add update property endpoint `/api/v1/property/:id` to property routes

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-authorize-update-property-167106396 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167106396

#### Screenshot
<img width="891" alt="authorize-test" src="https://user-images.githubusercontent.com/40744698/60729077-c6df8380-9f39-11e9-8495-65e8db780bbe.PNG">
<img width="947" alt="403" src="https://user-images.githubusercontent.com/40744698/60729122-dced4400-9f39-11e9-8b76-7766f8f6cc83.PNG">
