### PR TITLE
#167072398  Implement update property endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -14,10 +14,11 @@ export default class PropertyController {
       let { otherType } = req.body;
       otherType = !otherType ? null : otherType;
       status = !status ? 'Available' : status;
+      const newPrice = parseFloat(price);
       const property = new Property(
         id,
         owner,
-        price,
+        newPrice,
         state,
         city,
         address,
@@ -40,7 +41,7 @@ export default class PropertyController {
           state,
           city,
           address,
-          price,
+          price: newPrice,
           created_on,
           image_url: url,
           imageName: originalname,
@@ -49,6 +50,49 @@ export default class PropertyController {
         }
       });
     } catch (err) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
+
+  static async updateProperty(req, res) {
+    try {
+      const { prop } = req;
+      const { price, state, city, address, type, purpose } = req.body;
+      prop.purpose =
+        prop.purpose === purpose || !purpose ? prop.purpose : purpose;
+      prop.price =
+        prop.price === parseFloat(price) || !parseFloat(price)
+          ? prop.price
+          : parseFloat(price);
+      prop.state = prop.state === state || !state ? prop.state : state;
+      prop.city = prop.city === city || !city ? prop.city : city;
+      prop.address =
+        prop.address === address || !address ? prop.address : address;
+      prop.type = prop.type === type || !type ? prop.type : type;
+      const propIndex = properties.findIndex(({ id }) => id === prop.id);
+      properties.splice(propIndex, 1, prop);
+      return res.status(200).json({
+        status: 'Success',
+        data: {
+          id: prop.id,
+          status: prop.status,
+          type: prop.type,
+          state: prop.state,
+          city: prop.city,
+          address: prop.address,
+          price: prop.price,
+          created_on: prop.created_on,
+          image_url: prop.image_url,
+          imageName: prop.imageName,
+          purpose: prop.purpose,
+          otherType: prop.otherType
+        }
+      });
+    } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
         error:

--- a/API/src/data/data-structure/properties.js
+++ b/API/src/data/data-structure/properties.js
@@ -1,5 +1,3 @@
-import faker from 'faker';
-
 const properties = [
   {
     id: 1,
@@ -9,13 +7,14 @@ const properties = [
     city: 'Ojota',
     address: '20, Ojuka Street',
     type: 'Studio Flat',
-    imageName: '',
-    imageId: '',
-    image_url: faker.image.imageUrl(),
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334792/samples/test/mp0ba2f8izg3eefiehbl.jpg',
     purpose: 'For Rent',
     status: 'Available',
     created_on: new Date().toLocaleString(),
-    other_type: null
+    otherType: null
   },
   {
     id: 2,
@@ -25,13 +24,14 @@ const properties = [
     city: 'Akure',
     address: '20, Donga Street',
     type: 'Mini Flat',
-    imageName: '',
-    imageId: '',
-    image_url: faker.image.imageUrl(),
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334790/samples/test/iifzizmkrle6coaswlap.jpg',
     purpose: 'For Rent',
     status: 'Available',
     created_on: new Date().toLocaleString(),
-    other_type: null
+    otherType: null
   }
 ];
 export default properties;

--- a/API/src/middlewares/authorize.js
+++ b/API/src/middlewares/authorize.js
@@ -1,17 +1,18 @@
-import properties from '../data/data-structure/properties';
+import Property from '../services/property';
 /* eslint camelcase: 0 */
-const authorize = (req, res, next) => {
+const authorize = async (req, res, next) => {
   try {
     const propId = req.params.id;
-    const { is_admin } = req.auth;
-    if (is_admin) return next();
-    const requesterId = req.auth.id;
-    const property = properties.find(prop => prop.id === parseInt(propId, 10));
+    const property = await Property.findById(propId);
     if (!property)
       return res.status(404).json({
         status: '404 Not Found',
         error: "The property you requested to update doesn't exist"
       });
+    req.prop = { ...property };
+    const { is_admin } = req.auth;
+    if (is_admin) return next();
+    const requesterId = req.auth.id;
     const { owner } = property;
     if (requesterId !== owner)
       return res.status(403).json({

--- a/API/src/middlewares/image-upload.js
+++ b/API/src/middlewares/image-upload.js
@@ -1,6 +1,6 @@
 import multer from 'multer';
-import { storage } from '../utils/cloudinary';
-
+import { storage, deleteImgWithReturn } from '../utils/cloudinary';
+/* eslint camelcase: 0 */
 export default class ImageUpload {
   static multerUploader(req, res, next) {
     const multerUpload = multer({
@@ -24,6 +24,42 @@ export default class ImageUpload {
           status: '400 Bad Request',
           error: 'An Image is Required'
         });
+      return next();
+    });
+  }
+
+  static async multerUpdateUpload(req, res, next) {
+    const multerUpload = multer({
+      storage,
+      limits: { files: 1, fileSize: 750000 }
+    }).single('image');
+    multerUpload(req, res, async err => {
+      if (err instanceof multer.MulterError)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'Image should not exceed 750kb'
+        });
+
+      if (err)
+        return res.status(400).json({
+          status: '400 Bad Request',
+          error: 'Invalid File Format'
+        });
+
+      if (req.file) {
+        const { imageId } = req.prop;
+        const { result } = await deleteImgWithReturn(imageId);
+        if (result !== 'ok')
+          return res.status(500).json({
+            status: '500 Server Interval Error',
+            error:
+              'Something went wrong while processing your request, Do try again'
+          });
+        const { url, originalname, public_id } = req.file;
+        req.prop.image_url = url;
+        req.prop.imageId = public_id;
+        req.prop.imageName = originalname;
+      }
       return next();
     });
   }

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -19,7 +19,8 @@ router.patch(
   '/:id',
   Authenticate.verify,
   authorize,
-  ImageUpload.multerUploader
+  ImageUpload.multerUpdateUpload,
+  propertyController.updateProperty
 );
 
 export default router;

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -50,7 +50,8 @@ export default class Property extends PropertyModel {
       image_url,
       purpose,
       status,
-      created_on
+      created_on,
+      otherType
     } = this;
     const newLength = properties.push({
       id,
@@ -65,11 +66,17 @@ export default class Property extends PropertyModel {
       image_url,
       purpose,
       status,
-      created_on
+      created_on,
+      otherType
     });
     const isSaved =
       newLength > oldLength ? true : new Error('Property was not saved');
     if (isSaved) return isSaved;
     throw isSaved;
+  }
+
+  static async findById(propId) {
+    const property = properties.find(prop => prop.id === parseInt(propId, 10));
+    return property;
   }
 }

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -3,6 +3,8 @@ import path from 'path';
 import request from './auth.test';
 import { validToken, inValidToken } from '../utils/dummy';
 
+let testId = null;
+
 describe('Property Route Endpoints', () => {
   describe('POST api/v1/property', () => {
     it('should allow a authenticated user(Agent) to successfully post a property advert if he/she provides all the required data', done => {
@@ -25,6 +27,7 @@ describe('Property Route Endpoints', () => {
         .expect(201)
         .expect(res => {
           const { status, data } = res.body;
+          testId = data.id;
           expect(status).to.equal('Success');
           expect(data).to.have.all.keys(
             'id',
@@ -147,7 +150,7 @@ describe('Property Route Endpoints', () => {
   describe('UPDATE api/v1/property/:id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {
       request
-        .patch('/api/v1/property/2')
+        .patch(`/api/v1/property/${testId}`)
         .field('price', 700000)
         .field('state', 'Ekiti')
         .field('city', 'Ado')

--- a/API/src/utils/cloudinary.js
+++ b/API/src/utils/cloudinary.js
@@ -28,4 +28,9 @@ const deleteImage = publicId => {
   cloudinary.uploader.destroy(publicId);
 };
 
-export { storage, deleteImage };
+const deleteImgWithReturn = async publicId => {
+  const result = await cloudinary.uploader.destroy(publicId, async err => err);
+  return result;
+};
+
+export { storage, deleteImage, deleteImgWithReturn };


### PR DESCRIPTION
#### What does this PR do?
Add the update property API endpoint to enable authenticated users to update their property advert on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Add static method for handling property advert update to the property controller
- Add PATCH `/api/v1/property/:id` endpoint to property route

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-update-property-167072398 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a patch request to the URI `http://localhost:{{port}}/api/v1/property/:id` to test the update endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Update property using the data fields described in the entity specification for property advert

#### Any background context you want to provide?
 The data fields necessary for the request should be as specified in the requirement

#### What are the relevant pivotal tracker stories?
#167072398 

#### Screenshot
<img width="874" alt="update-feature" src="https://user-images.githubusercontent.com/40744698/60746539-08daea80-9f77-11e9-8535-496180050b1a.PNG">