### PR TITLE
#167072999 Add data validation to update-property endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -61,7 +61,15 @@ export default class PropertyController {
   static async updateProperty(req, res) {
     try {
       const { prop } = req;
-      const { price, state, city, address, type, purpose } = req.body;
+      const {
+        price,
+        state,
+        city,
+        address,
+        type,
+        purpose,
+        otherType
+      } = req.body;
       prop.purpose =
         prop.purpose === purpose || !purpose ? prop.purpose : purpose;
       prop.price =
@@ -72,9 +80,14 @@ export default class PropertyController {
       prop.city = prop.city === city || !city ? prop.city : city;
       prop.address =
         prop.address === address || !address ? prop.address : address;
-      prop.type = prop.type === type || !type ? prop.type : type;
-      const propIndex = properties.findIndex(({ id }) => id === prop.id);
-      properties.splice(propIndex, 1, prop);
+      const { newOtherType, newType } = Property.updateType(
+        prop,
+        type,
+        otherType
+      );
+      prop.type = newType;
+      prop.otherType = newOtherType;
+      await Property.updateAndSave(prop);
       return res.status(200).json({
         status: 'Success',
         data: {

--- a/API/src/middlewares/image-upload.js
+++ b/API/src/middlewares/image-upload.js
@@ -49,7 +49,7 @@ export default class ImageUpload {
       if (req.file) {
         const { imageId } = req.prop;
         const { result } = await deleteImgWithReturn(imageId);
-        if (result !== 'ok')
+        if (result !== 'ok' && result !== 'not found')
           return res.status(500).json({
             status: '500 Server Interval Error',
             error:

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -4,6 +4,7 @@ import ImageUpload from '../middlewares/image-upload';
 import Authenticate from '../middlewares/authenticate';
 import PostProperty from '../middlewares/post-property-validation';
 import authorize from '../middlewares/authorize';
+import UpdateProperty from '../middlewares/update-property-validation';
 
 const router = Router();
 
@@ -20,6 +21,8 @@ router.patch(
   Authenticate.verify,
   authorize,
   ImageUpload.multerUpdateUpload,
+  UpdateProperty.validate(),
+  UpdateProperty.verifyValidationResult,
   propertyController.updateProperty
 );
 

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -79,4 +79,40 @@ export default class Property extends PropertyModel {
     const property = properties.find(prop => prop.id === parseInt(propId, 10));
     return property;
   }
+
+  static updateType(
+    { otherType: savedOthers, type: savedType },
+    type,
+    otherType
+  ) {
+    let newOtherType;
+    let newType;
+    switch (type) {
+      case undefined:
+        newOtherType = !otherType ? savedOthers : otherType;
+        newType = savedType;
+        break;
+      case 'Others':
+        newType = type;
+        newOtherType = otherType;
+        break;
+      default:
+        newType = type;
+        newOtherType = null;
+        break;
+    }
+    return {
+      newOtherType,
+      newType
+    };
+  }
+
+  static async updateAndSave(property) {
+    try {
+      const propIndex = properties.findIndex(({ id }) => id === property.id);
+      properties.splice(propIndex, 1, property);
+    } catch (e) {
+      throw e;
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,12 +2593,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2613,17 +2615,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2740,7 +2745,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2752,6 +2758,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2766,6 +2773,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2773,12 +2781,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2797,6 +2807,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2877,7 +2888,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2889,6 +2901,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3010,6 +3023,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
#### What does this PR do?
Add data validation to the `/api/v1/property/:property-id` endpoint 

#### Description of Task to be completed?
Carry out the following Tasks 
- Add validation middleware 
- Modify the error handling implementation in the `image-upload middleware`
- Modify service for handling `property data transaction` to include methods that facilitate the  update of property adverts
- Add a `delete image` function that would ensure the old image of a property advert is deleted when an update is uploaded

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-validate-update-property-167072999 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`
- To test on postman, start the server with the command `npm run dev`
- Make a post request using the field parameters specified in the documentation through `/api/v1/signup` to obtain a token from the response
- Add the token as part of a header whose key is `x-access-token` to a post request through the `api/v1/property` endpoint so as to post a property advert
- Update posted property by appending the property's id as a parameter of the patch request through the `api/v1/property/{id}` and pass the appropriate data through the body of the request

#### What are the relevant pivotal tracker stories?
 #167105236 #167073662 #167072807 #167073305 #167073204 #167072888 #167072438 #167072999
 
#### Screenshot
<img width="898" alt="all-test-passing" src="https://user-images.githubusercontent.com/40744698/60818972-93e5fb80-a196-11e9-918b-2c074dc57e4a.PNG">



