### PR TITLE
 #167153763 Add unit tests for the mark sold/rented endpoint

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -3,11 +3,11 @@ import path from 'path';
 import request from './auth.test';
 import { validToken, inValidToken } from '../utils/dummy';
 
-let testId = null;
+let testPropertyId = null;
 
 describe('Property Route Endpoints', () => {
   describe('POST api/v1/property', () => {
-    it('should allow a authenticated user(Agent) to successfully post a property advert if he/she provides all the required data', done => {
+    it('should allow an authenticated user(Agent) to successfully post a property advert if he/she provides all the required data', done => {
       request
         .post('/api/v1/property')
         .field('status', 'Available')
@@ -27,7 +27,7 @@ describe('Property Route Endpoints', () => {
         .expect(201)
         .expect(res => {
           const { status, data } = res.body;
-          testId = data.id;
+          testPropertyId = data.id;
           expect(status).to.equal('Success');
           expect(data).to.have.all.keys(
             'id',
@@ -147,10 +147,10 @@ describe('Property Route Endpoints', () => {
     });
   });
   // update property
-  describe('UPDATE api/v1/property/:id', () => {
+  describe('UPDATE api/v1/property/:property-id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {
       request
-        .patch(`/api/v1/property/${testId}`)
+        .patch(`/api/v1/property/${testPropertyId}`)
         .field('price', 700000)
         .field('state', 'Ekiti')
         .field('city', 'Ado')
@@ -291,6 +291,86 @@ describe('Property Route Endpoints', () => {
         .field('state', 'Lagos')
         .field('purpose', 'For Rent')
         .set('Connection', 'keep-alive')
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(404)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('404 Not Found');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+  });
+  // mark property as sold/rent
+  describe('PATCH api/v1/property/:property-id/sold', () => {
+    it('should allow an authenticated user(Agent) to successfully mark his/her property as sold/rented', done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}/sold`)
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const { status, data } = res.body;
+          expect(status).to.equal('Success');
+          expect(data).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'purpose',
+            'imageName',
+            'otherType'
+          );
+        })
+        .end(done);
+    });
+    it("should prevent a user who doesn't provide an access token from marking a property as sold/rented", done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}/sold`)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Required');
+        })
+        .end(done);
+    });
+    it('should prevent a user with an Invalid token from marking a property as sold/rented', done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}/sold`)
+        .set('x-access-token', inValidToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Invalid');
+        })
+        .end(done);
+    });
+    it('should prevent any user except an Admin from marking a property advert posted by another user as sold/rented', done => {
+      request
+        .patch(`/api/v1/property/2/sold`)
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(403)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('403 Forbidden Request');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it("should return a resource not found error response whenever a user attempts to mark a property that doesn't exist sold/rented", done => {
+      request
+        .patch('/api/v1/property/78787058689/sold')
         .set('x-access-token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)


### PR DESCRIPTION
#### What does this PR do?
Add unit tests  for the API endpoint `/api/v1/property/:property-id/sold` that enables users to mark a property as sold/rented, checking the following:
- The app should prevent a user who has not been authenticated from marking a property advert as sold/rented
- The app should prevent a user from marking  an advert as sold/rented if he/she provides an invalid token in the request header
- The app should allow users who have been authenticated to successfully mark their property advert as sold or rented
- The app should prevent a user from marking a property advert as sold/rented if it was posted by another user except if the user in question is an admin
- The app should ensure a user gets an appropriate resource not found error response if he/she attempts to mark a property that doesn't exist as sold/rented

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify existing test script in `property.test.js`
- Create test script that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-mark-sold-test-167153763 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167153763 #167153879 #167153958 #167154747 #167154866

#### Screenshot
<img width="890" alt="mark-sold-rented-tests" src="https://user-images.githubusercontent.com/40744698/60853283-4350bb80-a1f3-11e9-9d5d-be47d64722cf.PNG">
