### PR TITLE
#167149685 Implement mark property sold/rented endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -67,6 +67,7 @@ export default class PropertyController {
         city,
         address,
         type,
+        status,
         purpose,
         otherType
       } = req.body;
@@ -77,6 +78,7 @@ export default class PropertyController {
           ? prop.price
           : parseFloat(price);
       prop.state = prop.state === state || !state ? prop.state : state;
+      prop.status = prop.status === status || !status ? prop.status : status;
       prop.city = prop.city === city || !city ? prop.city : city;
       prop.address =
         prop.address === address || !address ? prop.address : address;
@@ -103,6 +105,40 @@ export default class PropertyController {
           imageName: prop.imageName,
           purpose: prop.purpose,
           otherType: prop.otherType
+        }
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
+
+  static async markProperty(req, res) {
+    try {
+      const { prop: property } = req;
+      const { available } = req.query;
+      if (available === 'true') property.status = 'Available';
+      if (!available)
+        property.status = property.purpose === 'For Rent' ? 'Rented' : 'Sold';
+      await Property.updateAndSave(property);
+      return res.status(200).json({
+        status: 'Success',
+        data: {
+          id: property.id,
+          status: property.status,
+          type: property.type,
+          state: property.state,
+          city: property.city,
+          address: property.address,
+          price: property.price,
+          created_on: property.created_on,
+          image_url: property.image_url,
+          imageName: property.imageName,
+          purpose: property.purpose,
+          otherType: property.otherType
         }
       });
     } catch (e) {

--- a/API/src/middlewares/update-property-validation.js
+++ b/API/src/middlewares/update-property-validation.js
@@ -12,6 +12,22 @@ export default class UpdateProperty extends PostProperty {
         .withMessage('Field cannot be empty')
         .isIn([...status])
         .withMessage('should be either Available, Sold or Rented')
+        .custom((value, { req }) => {
+          if (value === 'Rented')
+            return (
+              req.body.purpose === 'For Rent' || req.prop.purpose === 'For Rent'
+            );
+          return true;
+        })
+        .withMessage('status can only be rented if the purpose is For Rent')
+        .custom((value, { req }) => {
+          if (value === 'Sold')
+            return (
+              req.body.purpose === 'For Sale' || req.prop.purpose === 'For Sale'
+            );
+          return true;
+        })
+        .withMessage('status can only be Sold if the purpose is For Sale')
         .trim(),
       check('price')
         .optional()

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -26,4 +26,10 @@ router.patch(
   propertyController.updateProperty
 );
 
+router.patch(
+  '/:id/sold',
+  Authenticate.verify,
+  authorize,
+  propertyController.markProperty
+);
 export default router;

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -357,7 +357,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent any user except an Admin from marking a property advert posted by another user as sold/rented', done => {
       request
-        .patch(`/api/v1/property/2/sold`)
+        .patch(`/api/v1/property/1/sold`)
         .set('x-access-token', validToken)
         .expect('Content-Type', /json/)
         .expect(403)


### PR DESCRIPTION
#### What does this PR do?
Add the mark a property sold/rented API endpoint `api/v1/property/:property-id/sold` to enable authenticated users to update the status of their property advert on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Add static method for handling marking a property advert sold or rented to the property controller
- Add PATCH `/api/v1/property/:id/sold` endpoint to property route
- Modify update property validation to ensure the status of a property is updated with reference to its  purpose value (that is, whether for rent or for sale)

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-mark-property-sold-167149685 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a patch request to the URI `http://localhost:{{port}}/api/v1/property/:property-id/sold` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167149685 #167153763 #167153879 #167153958 #167154747 #167154866

#### Screenshot
<img width="888" alt="test-passing" src="https://user-images.githubusercontent.com/40744698/60857658-49e72f00-a203-11e9-87ef-5528e37675ee.PNG">
