### PR TITLE
 #167184710 Add unit tests for delete property endpoint

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -382,4 +382,72 @@ describe('Property Route Endpoints', () => {
         .end(done);
     });
   });
+  describe('DELETE api/v1/property/:property-id', () => {
+    it('should allow an authenticated user(Agent) to successfully delete his/her property advert', done => {
+      request
+        .delete(`/api/v1/property/${testPropertyId}`)
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const {
+            body: { status, data }
+          } = res;
+          expect(status).to.equal('Success');
+          expect(data).to.have.all.keys('message');
+        })
+        .end(done);
+    });
+    it("should prevent a user who doesn't provide an access token from deleting a property", done => {
+      request
+        .delete(`/api/v1/property/${testPropertyId}/sold`)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Required');
+        })
+        .end(done);
+    });
+    it('should prevent a user with an Invalid token from deleting a property', done => {
+      request
+        .delete(`/api/v1/property/${testPropertyId}/sold`)
+        .set('x-access-token', inValidToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Invalid');
+        })
+        .end(done);
+    });
+    it('should prevent any user except an Admin from deleting a property advert posted by another user', done => {
+      request
+        .delete(`/api/v1/property/1`)
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(403)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('403 Forbidden Request');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it("should return a resource not found error response whenever a user attempts to delete a property that doesn't exist", done => {
+      request
+        .delete('/api/v1/property/78787058689')
+        .set('x-access-token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(404)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('404 Not Found');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Add unit tests for the API endpoint `/api/v1/property/:property-id` that enables users to delete a property. The unit test checks the following:
- The app should prevent a user who has not been authenticated from deleting his/her property advert 
- The app should prevent a user from deleting an advert  if he/she provides an invalid token in the request header
- The app should allow users who have been authenticated to successfully delete their property advert 
- The app should prevent a user from deleting a property advert  if it was posted by another user except if the user in question is an admin
- The app should ensure a user gets an appropriate resource not found error response if he/she attempts to delete a property that doesn't exist 

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify existing test script in `property.test.js`
- Create test script that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-delete-property-tests-167184710 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167184710 #167184711 #167184712 #167184713 #167184714

#### Screenshot
<img width="767" alt="delete-test-failing" src="https://user-images.githubusercontent.com/40744698/60930574-157c7d00-a2ae-11e9-96f2-c5ae96a2899a.PNG">
