### PR TITLE
#167185150 Implement delete property endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -149,4 +149,25 @@ export default class PropertyController {
       });
     }
   }
+
+  static async deleteProperty(req, res) {
+    const {
+      prop: { id: propertyId }
+    } = req;
+    try {
+      await Property.deleteById(propertyId);
+      return res.status(200).json({
+        status: 'Success',
+        data: {
+          message: `Successfully deleted property of id : ${propertyId}`
+        }
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
 }

--- a/API/src/middlewares/authorize.js
+++ b/API/src/middlewares/authorize.js
@@ -2,7 +2,7 @@ import Property from '../services/property';
 /* eslint camelcase: 0 */
 const authorize = async (req, res, next) => {
   try {
-    const propId = req.params.id;
+    const propId = req.params.propertyId;
     const property = await Property.findById(propId);
     if (!property)
       return res.status(404).json({

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -17,7 +17,7 @@ router.post(
   propertyController.postProperty
 );
 router.patch(
-  '/:id',
+  '/:propertyId',
   Authenticate.verify,
   authorize,
   ImageUpload.multerUpdateUpload,
@@ -27,9 +27,16 @@ router.patch(
 );
 
 router.patch(
-  '/:id/sold',
+  '/:propertyId/sold',
   Authenticate.verify,
   authorize,
   propertyController.markProperty
+);
+
+router.delete(
+  '/:propertyId',
+  Authenticate.verify,
+  authorize,
+  propertyController.deleteProperty
 );
 export default router;

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -108,11 +108,15 @@ export default class Property extends PropertyModel {
   }
 
   static async updateAndSave(property) {
-    try {
-      const propIndex = properties.findIndex(({ id }) => id === property.id);
-      properties.splice(propIndex, 1, property);
-    } catch (e) {
-      throw e;
-    }
+    const propIndex = properties.findIndex(({ id }) => id === property.id);
+    properties.splice(propIndex, 1, property);
+  }
+
+  static async deleteById(propertyId) {
+    const propIndex = properties.findIndex(({ id }) => id === propertyId);
+    const removed = properties.splice(propIndex, 1);
+    const isDeleted = removed.length === 1 ? true : new Error('not deleted');
+    if (isDeleted) return isDeleted;
+    throw isDeleted;
   }
 }

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -400,7 +400,7 @@ describe('Property Route Endpoints', () => {
     });
     it("should prevent a user who doesn't provide an access token from deleting a property", done => {
       request
-        .delete(`/api/v1/property/${testPropertyId}/sold`)
+        .delete(`/api/v1/property/${testPropertyId}`)
         .expect('Content-Type', /json/)
         .expect(401)
         .expect(res => {
@@ -412,7 +412,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent a user with an Invalid token from deleting a property', done => {
       request
-        .delete(`/api/v1/property/${testPropertyId}/sold`)
+        .delete(`/api/v1/property/${testPropertyId}`)
         .set('x-access-token', inValidToken)
         .expect('Content-Type', /json/)
         .expect(401)


### PR DESCRIPTION
#### What does this PR do?
Add the delete a property  API endpoint `api/v1/property/:property-id/` to enable authenticated users to delete  their property advert on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Add static method for handling delete functionality to the property controller
- Add `deleteById` method to the property service Class
- Add DELETE `/api/v1/property/:property-id` endpoint to property route

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-delete-property-167185150 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a DELETE request to the URI `http://localhost:{{port}}/api/v1/property/:property-id` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167185150 #167184710 #167184711 #167184712 #167184713 #167184714

#### Screenshot
<img width="886" alt="all-delete-test-passing" src="https://user-images.githubusercontent.com/40744698/60932491-26c98780-a2b6-11e9-8f40-0563dbd6e2fd.PNG">
