### PR TITLE
#167185520 Add unit test for get all property adverts

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -146,6 +146,40 @@ describe('Property Route Endpoints', () => {
         .end(done);
     });
   });
+  // get property
+  describe('GET api/v1/property', () => {
+    it('should return all property adverts at once or in chunks', done => {
+      request
+        .get(`/api/v1/property`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const {
+            body: { status, data }
+          } = res;
+          expect(status).to.equal('Success');
+          expect(data).to.be.an('array');
+          expect(data[0]).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'ownerEmail',
+            'ownerPhoneEmail',
+            'purpose',
+            'imageName',
+            'otherType'
+          );
+        })
+        .end(done);
+    });
+  });
+
   // update property
   describe('UPDATE api/v1/property/:property-id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {


### PR DESCRIPTION
#### What does this PR do?
Add unit tests for the GET API endpoint `/api/v1/property` that enables users to fetch all property adverts. The unit test checks that a user can view all property adverts on the App
#### Description of Task to be completed?
Add test case to `property.test.js` that checks the scenarios described above


#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-test-get-properties-167185520 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167185520

#### Screenshot
<img width="438" alt="get-all-properties" src="https://user-images.githubusercontent.com/40744698/60933618-f3d5c280-a2ba-11e9-97e9-b86568674e50.PNG">
