### PR TITLE
#167185528 Implement get all properties endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -4,6 +4,22 @@ import Property from '../services/property';
 
 export default class PropertyController {
   /* eslint camelcase: 0 */
+  static async getAllProperties(req, res) {
+    try {
+      const allProperties = await Property.fetchAll();
+      return res.status(200).json({
+        status: 'Success',
+        data: allProperties
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
+
   static async postProperty(req, res) {
     try {
       const { price, state, city, address, type, purpose } = req.body;

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -8,6 +8,7 @@ import UpdateProperty from '../middlewares/update-property-validation';
 
 const router = Router();
 
+router.get('/', propertyController.getAllProperties);
 router.post(
   '/',
   Authenticate.verify,

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -1,5 +1,6 @@
 import PropertyModel from '../models/propertyModel';
 import properties from '../data/data-structure/properties';
+import UserServices from './user';
 
 export default class Property extends PropertyModel {
   constructor(
@@ -118,5 +119,46 @@ export default class Property extends PropertyModel {
     const isDeleted = removed.length === 1 ? true : new Error('not deleted');
     if (isDeleted) return isDeleted;
     throw isDeleted;
+  }
+
+  static async fetchAll() {
+    const allProperties = properties.map(
+      async ({
+        id,
+        status,
+        type,
+        state,
+        city,
+        address,
+        price,
+        created_on,
+        image_url,
+        purpose,
+        otherType,
+        owner
+      }) => {
+        const {
+          email: ownerEmail,
+          phoneNumber: ownerPhoneNumber
+        } = await UserServices.findById(owner);
+        return {
+          id,
+          status,
+          type,
+          state,
+          city,
+          address,
+          price,
+          created_on,
+          image_url,
+          ownerEmail,
+          ownerPhoneNumber,
+          purpose,
+          otherType
+        };
+      }
+    );
+    const result = await Promise.all(allProperties);
+    return result;
   }
 }

--- a/API/src/services/user.js
+++ b/API/src/services/user.js
@@ -109,6 +109,11 @@ class User extends UserModel {
     const user = users.find(({ email }) => email === emailAddress);
     return user;
   }
+
+  static async findById(userId) {
+    const user = users.find(({ id }) => id === parseInt(userId, 10));
+    return user;
+  }
 }
 
 export default User;

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -170,9 +170,8 @@ describe('Property Route Endpoints', () => {
             'created_on',
             'image_url',
             'ownerEmail',
-            'ownerPhoneEmail',
+            'ownerPhoneNumber',
             'purpose',
-            'imageName',
             'otherType'
           );
         })


### PR DESCRIPTION
#### What does this PR do?
Add the get all property advert API endpoint `api/v1/property` to enable all users to fetch/view all property adverts on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Add a controller method for handling the request
- Add a `fetchAll` method to the property service Class
- Add a GET `/api/v1/property` endpoint to property route
- Add a `findById` to the User services class to fetch a user by his/her id

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-get-properties-167185528 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167185528 #167185520

#### Screenshot
<img width="895" alt="get-all-passing" src="https://user-images.githubusercontent.com/40744698/60967028-8b660000-a311-11e9-89d7-09a218ead76b.PNG">
<img width="960" alt="get-all-postman" src="https://user-images.githubusercontent.com/40744698/60967043-96b92b80-a311-11e9-986c-26cb75462383.PNG">
