### PR TITLE
#167212034 Add unit tests for fetching properties by specific type

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -178,7 +178,71 @@ describe('Property Route Endpoints', () => {
         .end(done);
     });
   });
-
+  // get properties by type
+  describe('GET api/v1/property?type=propertyType', () => {
+    it('should return all property adverts whose type is of Mini Flat', done => {
+      request
+        .get(`/api/v1/property?type=Mini Flat`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const {
+            body: { status, data }
+          } = res;
+          const { type } = data[0];
+          expect(type).to.equal('Mini Flat');
+          expect(status).to.equal('Success');
+          expect(data).to.be.an('array');
+          expect(data[0]).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'ownerEmail',
+            'ownerPhoneNumber',
+            'purpose',
+            'otherType'
+          );
+        })
+        .end(done);
+    });
+    it('should return all property adverts whose type is of 2 Bedroom', done => {
+      request
+        .get(`/api/v1/property?type=2 Bedroom`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const {
+            body: { status, data }
+          } = res;
+          const { type } = data[0];
+          expect(type).to.equal('2 Bedroom');
+          expect(status).to.equal('Success');
+          expect(data).to.be.an('array');
+          expect(data[0]).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'ownerEmail',
+            'ownerPhoneNumber',
+            'purpose',
+            'otherType'
+          );
+        })
+        .end(done);
+    });
+  });
   // update property
   describe('UPDATE api/v1/property/:property-id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {


### PR DESCRIPTION
#### What does this PR do?
Add unit tests for the GET API endpoint `/api/v1/property?type=propertyType` that enables users to fetch property adverts a by specific type. The unit test checks that a user can view a group of property advertisement of a specific type
#### Description of Task to be completed?
Add test case to `property.test.js` that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-test-view-by-type-167212034 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167212034

#### Screenshot
<img width="551" alt="test-for-propertyType" src="https://user-images.githubusercontent.com/40744698/61010665-1a553580-a36f-11e9-9fe3-7832018e294b.PNG">

