### PR TITLE
#167195473 Implement filter properties by type

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -6,7 +6,10 @@ export default class PropertyController {
   /* eslint camelcase: 0 */
   static async getAllProperties(req, res) {
     try {
-      const allProperties = await Property.fetchAll();
+      let allProperties;
+      const isQueryExist = Object.keys(req.query).length;
+      if (isQueryExist) allProperties = await Property.fetchByType(req.query);
+      else allProperties = await Property.fetchAll();
       return res.status(200).json({
         status: 'Success',
         data: allProperties

--- a/API/src/data/data-structure/properties.js
+++ b/API/src/data/data-structure/properties.js
@@ -32,6 +32,74 @@ const properties = [
     status: 'Available',
     created_on: new Date().toLocaleString(),
     otherType: null
+  },
+  {
+    id: 3,
+    owner: 1,
+    price: 6000.0,
+    state: 'Ondo',
+    city: 'Akure',
+    address: '20, Oke Street',
+    type: 'Mini Flat',
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334792/samples/test/mp0ba2f8izg3eefiehbl.jpg',
+    purpose: 'For Sale',
+    status: 'Available',
+    created_on: new Date().toLocaleString(),
+    otherType: null
+  },
+  {
+    id: 4,
+    owner: 1,
+    price: 4000.0,
+    state: 'Abia',
+    city: 'Konu',
+    address: '20, Kane Street',
+    type: 'Mini Flat',
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334792/samples/test/mp0ba2f8izg3eefiehbl.jpg',
+    purpose: 'For Rent',
+    status: 'Available',
+    created_on: new Date().toLocaleString(),
+    otherType: null
+  },
+  {
+    id: 5,
+    owner: 2,
+    price: 700000.0,
+    state: 'Ekiti',
+    city: 'Ado',
+    address: '20, Daniel Street',
+    type: '2 Bedroom',
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334790/samples/test/iifzizmkrle6coaswlap.jpg',
+    purpose: 'For Rent',
+    status: 'Available',
+    created_on: new Date().toLocaleString(),
+    otherType: null
+  },
+  {
+    id: 6,
+    owner: 2,
+    price: 100000.0,
+    state: 'Oyo',
+    city: 'Ibadan',
+    address: '20, Church Street',
+    type: '2 Bedroom',
+    imageName: 'o4yjhkbrmluwdzicmhih',
+    imageId: 'o4yjhkbrmluwdzicmhih',
+    image_url:
+      'https://res.cloudinary.com/propertypro/image/upload/v1562334790/samples/test/iifzizmkrle6coaswlap.jpg',
+    purpose: 'For Sale',
+    status: 'Available',
+    created_on: new Date().toLocaleString(),
+    otherType: null
   }
 ];
 export default properties;

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -121,6 +121,55 @@ export default class Property extends PropertyModel {
     throw isDeleted;
   }
 
+  static async fetchByType(queryObj) {
+    const { type: mainType } = queryObj;
+    let filteredProperties;
+    filteredProperties = properties.filter(
+      ({ type }) => type.toLowerCase() === mainType.toLowerCase()
+    );
+    if (!filteredProperties.length)
+      filteredProperties = properties.filter(
+        ({ type }) => type.toLowerCase() === 'others'
+      );
+    const allProperties = filteredProperties.map(async property => {
+      const {
+        id,
+        status,
+        type,
+        state,
+        city,
+        address,
+        price,
+        created_on,
+        image_url,
+        purpose,
+        otherType,
+        owner
+      } = property;
+      const {
+        email: ownerEmail,
+        phoneNumber: ownerPhoneNumber
+      } = await UserServices.findById(owner);
+      return {
+        id,
+        status,
+        type,
+        state,
+        city,
+        address,
+        price,
+        created_on,
+        image_url,
+        ownerEmail,
+        ownerPhoneNumber,
+        purpose,
+        otherType
+      };
+    });
+    const result = await Promise.all(allProperties);
+    return result;
+  }
+
   static async fetchAll() {
     const allProperties = properties.map(
       async ({


### PR DESCRIPTION
#### What does this PR do?
Add feature that enables Users to filter for a specific property type on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify the `getAllProperties` method of the propertyController to handle query parameters
- Add a `fetchByType` method to the property service Class
- Add more seeded data to the properties array to facilitate testing

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-view-by-type-167195473 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167195473 #167212034

#### Screenshot
<img width="878" alt="query-properties-passing" src="https://user-images.githubusercontent.com/40744698/61013518-dec06880-a37a-11e9-862b-c0babf2fc58b.PNG">
<img width="953" alt="quwer" src="https://user-images.githubusercontent.com/40744698/61013793-1ed41b00-a37c-11e9-987f-e60c72cec3ec.PNG">
