### PR TITLE
#167215238 Add more unit tests to view properties by type

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -242,6 +242,18 @@ describe('Property Route Endpoints', () => {
         })
         .end(done);
     });
+    it('should return a resource not found error response when a user filters for property adverts of a specific type that is currently not available on the App', done => {
+      request
+        .get(`/api/v1/property?type=Land`)
+        .expect('Content-Type', /json/)
+        .expect(404)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('404 Not Found');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
   });
   // update property
   describe('UPDATE api/v1/property/:property-id', () => {


### PR DESCRIPTION
#### What does this PR do?
Add a unit test to check that a user gets a `resource not found` response when he/she tries to filter the properties adverts on the App for a specific type of property that isn't available 
#### Description of Task to be completed?
Add test case to `property.test.js` that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-test-view-by-type-167215238 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167215238 #167195473

#### Screenshot
<img width="901" alt="property-not-found" src="https://user-images.githubusercontent.com/40744698/61015796-116f5e80-a385-11e9-9307-736220b31994.PNG">
