### PR TITLE
#167215242 Modify the view property adverts by type's Implementation

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -10,6 +10,11 @@ export default class PropertyController {
       const isQueryExist = Object.keys(req.query).length;
       if (isQueryExist) allProperties = await Property.fetchByType(req.query);
       else allProperties = await Property.fetchAll();
+      if (!allProperties)
+        return res.status(404).json({
+          status: '404 Not Found',
+          error: "The property adverts you request aren't available"
+        });
       return res.status(200).json({
         status: 'Success',
         data: allProperties

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -123,14 +123,10 @@ export default class Property extends PropertyModel {
 
   static async fetchByType(queryObj) {
     const { type: mainType } = queryObj;
-    let filteredProperties;
-    filteredProperties = properties.filter(
+    const filteredProperties = properties.filter(
       ({ type }) => type.toLowerCase() === mainType.toLowerCase()
     );
-    if (!filteredProperties.length)
-      filteredProperties = properties.filter(
-        ({ type }) => type.toLowerCase() === 'others'
-      );
+    if (!filteredProperties.length) return false;
     const allProperties = filteredProperties.map(async property => {
       const {
         id,


### PR DESCRIPTION
#### What does this PR do?
Add a response to accommodate a use case in which a user attempts to filter for property adverts of a specific type that isn't available on the App at that moment
#### Description of Task to be completed?
- Modify the `fetchByType` method in the property services class in return false if the filtered type isn't available
- Modify the `getAllProperties` method to return a 404 response error if the property adverts being filtered isn't available

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-refactor-view-by-type-167215242 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167215242 #167195473 #167215238

#### Screenshot
<img width="909" alt="test-pas" src="https://user-images.githubusercontent.com/40744698/61016888-34037680-a389-11e9-9cfc-a572f12406ae.PNG">
<img width="955" alt="not-available" src="https://user-images.githubusercontent.com/40744698/61016955-71680400-a389-11e9-910d-2d9686160cea.PNG">
