### PR TITLE
#167212331 Add unit test for view property endpoint

### DIFF
--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -255,6 +255,49 @@ describe('Property Route Endpoints', () => {
         .end(done);
     });
   });
+  // get single property
+  describe('GET api/v1/property/:property-id', () => {
+    it('should successfully return the property advert whose ID is specified', done => {
+      request
+        .get(`/api/v1/property/1`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const {
+            body: { status, data }
+          } = res;
+          expect(status).to.equal('Success');
+          expect(data).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'ownerEmail',
+            'ownerPhoneNumber',
+            'purpose',
+            'otherType'
+          );
+        })
+        .end(done);
+    });
+    it("should return a resource not found error response if the property ID specified doesn't match the existing property adverts", done => {
+      request
+        .get(`/api/v1/property/67585959500`)
+        .expect('Content-Type', /json/)
+        .expect(404)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('404 Not Found');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+  });
   // update property
   describe('UPDATE api/v1/property/:property-id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {


### PR DESCRIPTION
#### What does this PR do?
Add a unit tests to the endpoint `/api/v1/property/property-id` ; which checks the following:
- A user should be able to fetch or view a single property advert by making a GET request with the property advert's ID as a parameter
- A user should get a `resource not found` error response if he provides an ID that doesn't exist when making the request
#### Description of Task to be completed?
Add test case to `property.test.js` that checks the scenarios described above

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-test-get-property-167212331 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167212331

#### Screenshot
<img width="922" alt="failing-single" src="https://user-images.githubusercontent.com/40744698/61018305-416f2f80-a38e-11e9-988a-59bd0d0b40fd.PNG">
