### PR TITLE
#167195495 Implement view a property endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -28,6 +28,30 @@ export default class PropertyController {
     }
   }
 
+  static async getProperty(req, res) {
+    const {
+      params: { propertyId }
+    } = req;
+    try {
+      const property = await Property.fetchById(propertyId);
+      if (!property)
+        return res.status(404).json({
+          status: '404 Not Found',
+          error: 'The property advert you have requested is not available'
+        });
+      return res.status(200).json({
+        status: 'Success',
+        data: property
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: '500 Server Interval Error',
+        error:
+          'Something went wrong while processing your request, Do try again'
+      });
+    }
+  }
+
   static async postProperty(req, res) {
     try {
       const { price, state, city, address, type, purpose } = req.body;

--- a/API/src/routes/property.js
+++ b/API/src/routes/property.js
@@ -9,6 +9,7 @@ import UpdateProperty from '../middlewares/update-property-validation';
 const router = Router();
 
 router.get('/', propertyController.getAllProperties);
+router.get('/:propertyId', propertyController.getProperty);
 router.post(
   '/',
   Authenticate.verify,

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -77,8 +77,46 @@ export default class Property extends PropertyModel {
   }
 
   static async findById(propId) {
-    const property = properties.find(prop => prop.id === parseInt(propId, 10));
+    const property = properties.find(({ id }) => id === parseInt(propId, 10));
     return property;
+  }
+
+  static async fetchById(propertyId) {
+    const property = await Property.findById(propertyId);
+    if (!property) return property;
+    const {
+      id,
+      status,
+      type,
+      state,
+      city,
+      address,
+      price,
+      created_on,
+      image_url,
+      purpose,
+      otherType,
+      owner
+    } = property;
+    const {
+      email: ownerEmail,
+      phoneNumber: ownerPhoneNumber
+    } = await UserServices.findById(owner);
+    return {
+      id,
+      status,
+      type,
+      state,
+      city,
+      address,
+      price,
+      created_on,
+      image_url,
+      ownerEmail,
+      ownerPhoneNumber,
+      purpose,
+      otherType
+    };
   }
 
   static updateType(


### PR DESCRIPTION
#### What does this PR do?
Add view a property endpoint (`/api/v1/property/:property-id`) that enables users to view a specific property

#### Description of Task to be completed?
Carry out the following Tasks 
- Add `getProperty` method to property controller
- Add a `fetchById` method to the property service Class
- Add `/api/v1/property/:property-id` endpoint to the property route

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-view-property-167195495 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property/:property-id` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167195495 #167212331 #167213481

#### Screenshot
<img width="892" alt="propertyId" src="https://user-images.githubusercontent.com/40744698/61020969-77fd7800-a397-11e9-84bc-8d6507daa82b.PNG">
<img width="942" alt="single-property" src="https://user-images.githubusercontent.com/40744698/61020982-82b80d00-a397-11e9-9759-56510f301597.PNG">
