### PR TITLE
 #167216595 Modify validation for post and update property

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -54,14 +54,15 @@ export default class PropertyController {
 
   static async postProperty(req, res) {
     try {
-      const { price, state, city, address, type, purpose } = req.body;
+      const { price, state, city, address, type } = req.body;
       const owner = req.auth.id;
       const { url, originalname, public_id } = req.file;
       const id = await Helpers.createId(properties);
-      let { status } = req.body;
-      let { otherType } = req.body;
+      let { status, otherType, purpose } = req.body;
       otherType = !otherType ? null : otherType;
       status = !status ? 'Available' : status;
+      purpose = !purpose ? 'For Sale' : purpose;
+      purpose = status === 'Rented' ? 'For Rent' : purpose;
       const newPrice = parseFloat(price);
       const property = new Property(
         id,

--- a/API/src/middlewares/update-property-validation.js
+++ b/API/src/middlewares/update-property-validation.js
@@ -1,6 +1,7 @@
 import { check } from 'express-validator';
 import { states, type, purpose, status } from '../utils/validation-data';
 import PostProperty from './post-property-validation';
+import Helpers from '../utils/helpers';
 
 export default class UpdateProperty extends PostProperty {
   static validate() {
@@ -10,20 +11,31 @@ export default class UpdateProperty extends PostProperty {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
+        .customSanitizer(Helpers.capitalizeFirst)
         .isIn([...status])
         .withMessage('should be either Available, Sold or Rented')
         .custom((value, { req }) => {
+          const {
+            body: { purpose: selectedPurpose },
+            prop: { purpose: storedPurpose }
+          } = req;
           if (value === 'Rented')
             return (
-              req.body.purpose === 'For Rent' || req.prop.purpose === 'For Rent'
+              Helpers.capitalizeEachWord(selectedPurpose) === 'For Rent' ||
+              storedPurpose === 'For Rent'
             );
           return true;
         })
         .withMessage('status can only be rented if the purpose is For Rent')
         .custom((value, { req }) => {
+          const {
+            body: { purpose: selectedPurpose },
+            prop: { purpose: storedPurpose }
+          } = req;
           if (value === 'Sold')
             return (
-              req.body.purpose === 'For Sale' || req.prop.purpose === 'For Sale'
+              Helpers.capitalizeEachWord(selectedPurpose) === 'For Sale' ||
+              storedPurpose === 'For Sale'
             );
           return true;
         })
@@ -45,6 +57,7 @@ export default class UpdateProperty extends PostProperty {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
+        .customSanitizer(Helpers.capitalizeFirst)
         .isIn([...states])
         .withMessage('should be one of the states listed')
         .trim(),
@@ -73,6 +86,7 @@ export default class UpdateProperty extends PostProperty {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
+        .customSanitizer(Helpers.capitalizeEachWord)
         .isIn([...type])
         .withMessage('should be one of the types listed')
         .custom((value, { req }) => {
@@ -109,6 +123,7 @@ export default class UpdateProperty extends PostProperty {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
+        .customSanitizer(Helpers.capitalizeEachWord)
         .isIn([...purpose])
         .withMessage('should be one of the types listed')
     ];

--- a/API/src/utils/helpers.js
+++ b/API/src/utils/helpers.js
@@ -5,5 +5,37 @@ class Helpers {
     const id = arr[length - 1].id + 1;
     return id;
   }
+
+  static capitalizeFirst(value) {
+    try {
+      if (!value || typeof value !== 'string') return value;
+      const convertedToLowerCase = value.toLowerCase();
+      const capitalized =
+        convertedToLowerCase.charAt(0).toUpperCase() +
+        convertedToLowerCase.slice(1);
+
+      return capitalized;
+    } catch (e) {
+      return value;
+    }
+  }
+
+  static capitalizeEachWord(value) {
+    try {
+      if (!value || typeof value !== 'string') return value;
+      const splitedBySpace = value.split(' ');
+      const formatEachWord = splitedBySpace.map(word => {
+        const convertedToLowerCase = word.toLowerCase();
+        const capitalized =
+          convertedToLowerCase.charAt(0).toUpperCase() +
+          convertedToLowerCase.slice(1);
+        return capitalized;
+      });
+      const reCombinedWords = formatEachWord.join(' ');
+      return reCombinedWords;
+    } catch (e) {
+      return value;
+    }
+  }
 }
 export default Helpers;


### PR DESCRIPTION
#### What does this PR do?
Refactor the post and update property process on the App to allow users to optionally provide a value for the purpose and status fields
#### Description of Task to be completed?
- Modify `postProperty` method on the property controller to accommodate default values for purpose
- Add two custom sanitizer methods to the helper Class in the utils folder that helps ensure data are validated without case-sensitivity issues
- Modify update-property and post-property validation middlewares

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-refactor-property-field-167215242 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a POST request to the URI `http://localhost:{{port}}/api/v1/property` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### Any background context you want to provide?
The data fields used during testing should be provided in line with the entity specification on page 13 of the ADC documentation for PropertyPro Lite

#### What are the relevant pivotal tracker stories?
 #167216595 
