### PR TITLE
#167279043 Implement signup with persistence

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "singleQuote" : true
+    "singleQuote" : true,
+    "printWidth" : 90
 }

--- a/API/src/controllers/authController.js
+++ b/API/src/controllers/authController.js
@@ -1,36 +1,16 @@
 import User from '../services/user';
-import Helpers from '../utils/helpers';
-import users from '../data/data-structure/users';
 
 class Auth {
   /* eslint camelcase: 0 */
   static async signUp(req, res) {
-    const {
-      first_name,
-      last_name,
-      address,
-      gender,
-      email,
-      password,
-      phoneNumber
-    } = req.body;
+    const { first_name, last_name, address, email, password, phone_number } = req.body;
     try {
-      const id = await Helpers.createId(users);
       const pass = await User.hashPassword(password);
-      const user = new User(
-        id,
-        first_name,
-        last_name,
-        gender,
-        email,
-        address,
-        pass,
-        phoneNumber
-      );
-      await user.save();
-      const token = user.generateToken();
+      const user = new User(first_name, last_name, email, address, pass, phone_number);
+      const { id, is_admin } = await user.save();
+      const token = User.generateToken(id, is_admin);
       return res.status(201).json({
-        status: 'Success',
+        status: 'success',
         data: {
           token,
           id,
@@ -42,8 +22,7 @@ class Auth {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -78,8 +57,7 @@ class Auth {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }

--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -22,8 +22,7 @@ export default class PropertyController {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -46,8 +45,7 @@ export default class PropertyController {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -101,8 +99,7 @@ export default class PropertyController {
     } catch (err) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -110,18 +107,8 @@ export default class PropertyController {
   static async updateProperty(req, res) {
     try {
       const { prop } = req;
-      const {
-        price,
-        state,
-        city,
-        address,
-        type,
-        status,
-        purpose,
-        otherType
-      } = req.body;
-      prop.purpose =
-        prop.purpose === purpose || !purpose ? prop.purpose : purpose;
+      const { price, state, city, address, type, status, purpose, otherType } = req.body;
+      prop.purpose = prop.purpose === purpose || !purpose ? prop.purpose : purpose;
       prop.price =
         prop.price === parseFloat(price) || !parseFloat(price)
           ? prop.price
@@ -129,13 +116,8 @@ export default class PropertyController {
       prop.state = prop.state === state || !state ? prop.state : state;
       prop.status = prop.status === status || !status ? prop.status : status;
       prop.city = prop.city === city || !city ? prop.city : city;
-      prop.address =
-        prop.address === address || !address ? prop.address : address;
-      const { newOtherType, newType } = Property.updateType(
-        prop,
-        type,
-        otherType
-      );
+      prop.address = prop.address === address || !address ? prop.address : address;
+      const { newOtherType, newType } = Property.updateType(prop, type, otherType);
       prop.type = newType;
       prop.otherType = newOtherType;
       await Property.updateAndSave(prop);
@@ -159,8 +141,7 @@ export default class PropertyController {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -193,8 +174,7 @@ export default class PropertyController {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }
@@ -214,8 +194,7 @@ export default class PropertyController {
     } catch (e) {
       return res.status(500).json({
         status: '500 Server Interval Error',
-        error:
-          'Something went wrong while processing your request, Do try again'
+        error: 'Something went wrong while processing your request, Do try again'
       });
     }
   }

--- a/API/src/middlewares/signup-validation.js
+++ b/API/src/middlewares/signup-validation.js
@@ -32,7 +32,6 @@ export default class SignUp {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
-        .normalizeEmail()
         .isEmail()
         .withMessage('Should be a valid Email Address'),
       check('confirm_password')
@@ -59,9 +58,7 @@ export default class SignUp {
         .isEmpty()
         .withMessage('Field cannot be empty')
         .isNumeric()
-        .withMessage(
-          'Should be plain numbers without a country code or a + sign'
-        )
+        .withMessage('Should be plain numbers without a country code or a + sign')
         .isLength({ max: 11, min: 9 })
         .withMessage('Should be atleast 9-11 characters')
     ];
@@ -98,7 +95,7 @@ export default class SignUp {
 
   static async isEmailAlreadyExist(req, res, next) {
     const { email } = req.body;
-    const user = await UserServices.getUserByEmail(email);
+    const user = await UserServices.findByEmail(email);
     if (user)
       return res.status(409).json({
         status: '409 Conflict',

--- a/API/src/models/userModel.js
+++ b/API/src/models/userModel.js
@@ -3,20 +3,18 @@ export default class User {
     id,
     firstName,
     lastName,
-    gender,
     email,
     address,
     password,
     phone,
-    isAdmin = false
+    isAdmin
   ) {
     this.id = id;
     this.first_name = firstName;
     this.last_name = lastName;
-    this.gender = gender;
     this.email = email;
     this.address = address;
-    this.phoneNumber = phone;
+    this.phone_number = phone;
     this.password = password;
     this.is_admin = isAdmin;
   }

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -70,8 +70,7 @@ export default class Property extends PropertyModel {
       created_on,
       otherType
     });
-    const isSaved =
-      newLength > oldLength ? true : new Error('Property was not saved');
+    const isSaved = newLength > oldLength ? true : new Error('Property was not saved');
     if (isSaved) return isSaved;
     throw isSaved;
   }
@@ -119,11 +118,7 @@ export default class Property extends PropertyModel {
     };
   }
 
-  static updateType(
-    { otherType: savedOthers, type: savedType },
-    type,
-    otherType
-  ) {
+  static updateType({ otherType: savedOthers, type: savedType }, type, otherType) {
     let newOtherType;
     let newType;
     switch (type) {

--- a/API/src/utils/dummy.js
+++ b/API/src/utils/dummy.js
@@ -4,7 +4,7 @@ import UserServices from '../services/user';
 // signup data
 //  valid user data
 const validUserData = {
-  email: faker.internet.email(),
+  email: 'daylay863@gmail.com',
   first_name: 'King',
   last_name: 'Ayodele',
   password: 'rrft3456',
@@ -37,7 +37,7 @@ const invalidUserData = {
 
 //  already existing user data
 const alreadyExistingUserData = {
-  email: 'zaylay92@yahoo.com',
+  email: 'john.doe@gmail.com',
   first_name: 'Sam',
   last_name: 'Sung',
   password: 'King1234',
@@ -49,8 +49,8 @@ const alreadyExistingUserData = {
 // login credentials
 // Valid credentials
 const validLoginCredentials = {
-  email: 'zaylay92@yahoo.com',
-  password: 'ayo1234'
+  email: 'john.doe@gmail.com',
+  password: 'johnny'
 };
 // Invalid credentials
 const invalidLoginCredentials = {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "test": "nyc --reporter=text mocha ./API/src/**/*.test.js -r @babel/register --timeout 30000 --exit true",
     "start": "node ./API/lib/app.js",
     "dev": "nodemon --exec babel-node ./API/src/app.js",
-    "build": "babel ./API/src -d ./API/lib --cppy-files",
+    "build": "babel ./API/src -d ./API/lib --copy-files",
     "test-build": "nyc --reporter=lcov mocha ./API/src/**/*.test.js -r @babel/register --timeout 30000 --exit true",
     "coveralls": "nyc npm run test-build && nyc report --reporter=text-lcov | coveralls",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "migrations" : "babel-node ./API/src/data/db/migrations.js"
+    "migrations" : "babel-node ./API/src/data/db/migrations.js",
+    "local-test": "npm run migrations && npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### What does this PR do?
Add database implementation to the signup process

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify the save method in  `API/src/services/user.js` to include a parameterized database query for storing new users
- Modify User schema in `API/src/models/userModel.js` and the corresponding inheritance behavior in  `API/src/services/user.js`
- Create new method to find User by email in `API/src/services/user.js` and updated signup-validation middleware with the new changes

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-signup-167279043 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Launch postman once the app is up to start testing the signup endpoint
- Ensure to include a .env file containing a PORT variable whose value should correspond to a port with which the App would listen for requests
 
#### Any background context you want to provide?
- All API endpoints for this app are prefixed with `api/v1`, hence testing locally would implies the URI is formed as `http://localhost:{{PORT}}/api/v1/{{endpoint}}` where endpoint for signup is auth/signup
- Look up the request field specification for signup in the ADC requirement on page 13

#### What are the relevant pivotal tracker stories?
#167279043

#### Screenshot
<img width="943" alt="signup" src="https://user-images.githubusercontent.com/40744698/61189920-25200b00-a68c-11e9-8908-3a725ffe143b.PNG">
<img width="601" alt="db-signup" src="https://user-images.githubusercontent.com/40744698/61189928-3406bd80-a68c-11e9-8216-ad713d5f987d.PNG">
