### PR TITLE
 #167281328 Implement signin database interaction

### DIFF
--- a/API/src/middlewares/post-property-validation.js
+++ b/API/src/middlewares/post-property-validation.js
@@ -70,9 +70,7 @@ export default class PostProperty {
           if (value.trim() === 'Others') return req.body.other_type;
           return true;
         })
-        .withMessage(
-          'the type selected requires that you fill the other-type field'
-        )
+        .withMessage('the type selected requires that you fill the other-type field')
         .trim()
         .escape(),
       check('other_type')
@@ -109,9 +107,7 @@ export default class PostProperty {
             );
           return true;
         })
-        .withMessage(
-          'should be selected only if status was set to Available or Sold'
-        )
+        .withMessage('should be selected only if status was set to Available or Sold')
         .custom((value, { req }) => {
           const {
             body: { status: propertyStatus }
@@ -124,9 +120,7 @@ export default class PostProperty {
             );
           return true;
         })
-        .withMessage(
-          'should be selected only if status was set to Available or Rented'
-        )
+        .withMessage('should be selected only if status was set to Available or Rented')
         .trim()
         .escape(),
       check('image_url')

--- a/API/src/middlewares/signin-validation.js
+++ b/API/src/middlewares/signin-validation.js
@@ -9,7 +9,6 @@ export default class SignIn {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
-        .normalizeEmail()
         .isEmail()
         .withMessage('Invalid Email Address'),
       check('password')

--- a/API/src/services/user.js
+++ b/API/src/services/user.js
@@ -46,7 +46,7 @@ class User extends UserModel {
             VALUES($1, $2, $3, $4, $5, $6, $7)
             returning id`;
     const values = [
-      email,
+      email.toLowerCase(),
       first_name,
       last_name,
       password,
@@ -86,7 +86,7 @@ class User extends UserModel {
 
   static async findByEmail(email) {
     const text = `SELECT * FROM users WHERE email= $1`;
-    const value = [email];
+    const value = [email.toLowerCase()];
     const {
       rows: [user]
     } = await db.queryWithParams(text, value);


### PR DESCRIPTION
#### What does this PR do?
Add database implementation to the signin process

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify `signIn` method in the auth controller class and add database interaction via the `findByEmail` of the user services class
- Remove `normalizeEmail` method to reduce restriction on email composition during validation


#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-signin-167281328 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Launch postman once the app is up to start testing the signin endpoint
- Ensure to include a .env file containing a PORT variable whose value should correspond to a port with which the App would listen for requests
 
#### Any background context you want to provide?
- All API endpoints for this app are prefixed with `api/v1`, hence testing locally would implies the URI is formed as `http://localhost:{{PORT}}/api/v1/{{endpoint}}` where endpoint for signin is auth/signin
- Look up the request field specification for signup in the ADC requirement on page 13

#### What are the relevant pivotal tracker stories?
#167281328

#### Screenshot
<img width="943" alt="signin" src="https://user-images.githubusercontent.com/40744698/61190687-63232c00-a698-11e9-89dd-3905f22a5a11.PNG">
<img width="637" alt="signin-postman" src="https://user-images.githubusercontent.com/40744698/61190697-6a4a3a00-a698-11e9-8c75-90f77652492a.PNG">
