### PR TITLE
#167281641 Add persistence to post-property endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -1,5 +1,3 @@
-import Helpers from '../utils/helpers';
-import properties from '../data/data-structure/properties';
 import Property from '../services/property';
 
 export default class PropertyController {
@@ -52,35 +50,45 @@ export default class PropertyController {
 
   static async postProperty(req, res) {
     try {
-      const { price, state, city, address, type } = req.body;
-      const owner = req.auth.id;
-      const { url, originalname, public_id } = req.file;
-      const id = await Helpers.createId(properties);
-      let { status, otherType, purpose } = req.body;
-      otherType = !otherType ? null : otherType;
-      status = !status ? 'Available' : status;
-      purpose = !purpose ? 'For Sale' : purpose;
-      purpose = status === 'Rented' ? 'For Rent' : purpose;
+      const {
+        body: {
+          price,
+          status = 'available',
+          city,
+          address,
+          type,
+          other_type = null,
+          image_url,
+          image_id = null,
+          image_name = null,
+          purpose,
+          state,
+          description = null
+        },
+        auth: { id: owner }
+      } = req;
+      let reason = !purpose ? 'for sale' : purpose;
+      reason = status === 'rented' ? 'for rent' : reason;
       const newPrice = parseFloat(price);
       const property = new Property(
-        id,
         owner,
         newPrice,
         state,
         city,
         address,
         type,
-        originalname,
-        public_id,
-        url,
-        purpose,
+        image_name,
+        image_id,
+        image_url,
+        reason,
         status,
-        otherType
+        other_type,
+        null,
+        description
       );
-      const { created_on } = property;
-      await property.save();
+      const { created_on, id } = await property.save();
       return res.status(201).json({
-        status: 'Success',
+        status: 'success',
         data: {
           id,
           status,
@@ -90,10 +98,11 @@ export default class PropertyController {
           address,
           price: newPrice,
           created_on,
-          image_url: url,
-          imageName: originalname,
-          purpose,
-          otherType
+          image_url,
+          purpose: reason,
+          image_name,
+          other_type,
+          description
         }
       });
     } catch (err) {

--- a/API/src/middlewares/authenticate.js
+++ b/API/src/middlewares/authenticate.js
@@ -6,24 +6,27 @@ config();
 export default class Authenticate {
   static async verify(req, res, next) {
     const {
-      headers: { token: headerToken },
-      body: { token: bodyToken }
+      body: { token: bodyToken = null },
+      headers: { token: headerToken = null }
     } = req;
-    const token = headerToken || bodyToken;
-    if (token)
-      jwt.verify(token, process.env.SIGN_SECRET, (err, decoded) => {
-        if (err)
-          return res.status(401).json({
-            status: '401 Unauthorized',
-            error: 'Access token is Invalid'
-          });
-        const { data } = decoded;
-        req.auth = { ...data };
-        return next();
+    const token = !headerToken ? bodyToken : headerToken;
+
+    if (!token) {
+      res.status(401).json({
+        status: '401 Unauthorized',
+        error: 'Access token is Required'
       });
-    return res.status(401).json({
-      status: '401 Unauthorized',
-      error: 'Access token is Required'
+      return;
+    }
+    jwt.verify(token, process.env.SIGN_SECRET, (err, decoded) => {
+      if (err)
+        return res.status(401).json({
+          status: '401 Unauthorized',
+          error: 'Access token is Invalid'
+        });
+      const { data } = decoded;
+      req.auth = { ...data };
+      return next();
     });
   }
 }

--- a/API/src/middlewares/image-upload.js
+++ b/API/src/middlewares/image-upload.js
@@ -19,7 +19,11 @@ export default class ImageUpload {
           status: '400 Bad Request',
           error: 'Invalid File Format'
         });
-      if (req.file) req.image_url = req.file.url;
+      if (req.file) {
+        req.body.image_url = req.file.url;
+        req.body.image_id = req.file.public_id;
+        req.body.image_name = req.file.originalname;
+      }
       return next();
     });
   }

--- a/API/src/middlewares/post-property-validation.js
+++ b/API/src/middlewares/post-property-validation.js
@@ -1,6 +1,6 @@
 import { check, validationResult } from 'express-validator';
 import Helpers from '../utils/helpers';
-import { states, purpose, status } from '../utils/validation-data';
+import { purpose, status } from '../utils/validation-data';
 import { deleteImage } from '../utils/cloudinary';
 
 export default class PostProperty {
@@ -24,8 +24,8 @@ export default class PostProperty {
         .isLength({ min: 3, max: 15 })
         .withMessage('should be between 3-15 characters long')
         .trim()
-        .matches(/^\d+(\.|\d)\d+$/)
-        .withMessage('should be a float or numbers')
+        .matches(/^\d+(\.|\d)\d\d$/)
+        .withMessage('should be a float or a number e.g 5000.00 or 5000')
         .escape(),
       check('state')
         .exists()
@@ -33,9 +33,7 @@ export default class PostProperty {
         .not()
         .isEmpty()
         .withMessage('Field cannot be empty')
-        .customSanitizer(Helpers.capitalizeFirst)
-        .isIn([...states])
-        .withMessage('should be one of the states in Nigeria')
+        .customSanitizer(Helpers.capitalize)
         .trim(),
       check('city')
         .exists()

--- a/API/src/models/propertyModel.js
+++ b/API/src/models/propertyModel.js
@@ -12,7 +12,10 @@ export default class Property {
     imageUrl,
     purpose,
     status,
-    otherType
+    otherType,
+    description,
+    updatedOn,
+    createdOn
   ) {
     this.id = id;
     this.owner = owner;
@@ -22,11 +25,13 @@ export default class Property {
     this.city = city;
     this.address = address;
     this.type = type;
-    this.imageName = imageName;
-    this.imageId = imageId;
+    this.image_name = imageName;
+    this.image_id = imageId;
     this.image_url = imageUrl;
     this.purpose = purpose;
-    this.created_on = new Date().toLocaleString();
-    this.otherType = otherType;
+    this.created_on = createdOn;
+    this.other_type = otherType;
+    this.description = description;
+    this.updated_on = updatedOn;
   }
 }

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -38,7 +38,8 @@ describe('Property Route Endpoints', () => {
             'image_url',
             'purpose',
             'image_name',
-            'other_type'
+            'other_type',
+            'description'
           );
         })
         .end(done);

--- a/API/src/utils/helpers.js
+++ b/API/src/utils/helpers.js
@@ -1,29 +1,9 @@
 class Helpers {
-  static async createId(arr) {
-    const { length } = arr;
-    if (length === 0) return 1;
-    const id = arr[length - 1].id + 1;
-    return id;
-  }
-
-  static capitalizeFirst(value) {
-    try {
-      if (!value || typeof value !== 'string') return value;
-      const convertedToLowerCase = value.toLowerCase();
-      const capitalized =
-        convertedToLowerCase.charAt(0).toUpperCase() + convertedToLowerCase.slice(1);
-
-      return capitalized;
-    } catch (e) {
-      return value;
-    }
-  }
-
   static toSmallLetters(value) {
     return value.toLowerCase();
   }
 
-  static capitalizeEachWord(value) {
+  static capitalize(value) {
     try {
       if (!value || typeof value !== 'string') return value;
       const splitedBySpace = value.split(' ');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,6 +4569,11 @@
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-build": "nyc --reporter=lcov mocha ./API/src/**/*.test.js -r @babel/register --timeout 30000 --exit true",
     "coveralls": "nyc npm run test-build && nyc report --reporter=text-lcov | coveralls",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "migrations" : "babel-node ./API/src/data/db/migrations.js",
+    "migrations": "babel-node ./API/src/data/db/migrations.js",
     "local-test": "npm run migrations && npm test"
   },
   "repository": {
@@ -65,6 +65,7 @@
     "express-validator": "^6.1.1",
     "faker": "^4.1.0",
     "jsonwebtoken": "^8.5.1",
+    "moment": "^2.24.0",
     "multer": "^1.4.1",
     "multer-storage-cloudinary": "^2.2.1",
     "pg": "^7.11.0",


### PR DESCRIPTION
#### What does this PR do?
Add database implementation to post property endpoint
#### Description of Task to be completed?
Carry out the following Tasks 
- Modify the save method in  `API/src/services/property.js` to include a parameterized database query for storing new users
- Modify property schema in `API/src/models/propertyModel.js` and the corresponding inheritance behavior in  `API/src/services/property.js`
- Make changes to post-property-validation middleware 
- Make changes to authentication middleware

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-post-property-167281641 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Launch postman once the app is up to start testing the post-property endpoint
- Ensure to include a .env file containing a PORT variable whose value should correspond to a port with which the App would listen for requests
- Add configuration for cloudinary to .env file
 
#### Any background context you want to provide?
- All API endpoints for this app are prefixed with `api/v1`, hence testing locally would implies the URI is formed as `http://localhost:{{PORT}}/api/v1/{{endpoint}}` where endpoint for post-property is property/signup
- Look up the request field specification for post property in the ADC requirement on page 13

#### What are the relevant pivotal tracker stories?
#167281641

#### Screenshot
<img width="939" alt="post-prop" src="https://user-images.githubusercontent.com/40744698/61210270-e02fbf00-a6f3-11e9-81b3-e6a857b7fa9f.PNG">

<img width="888" alt="postproper" src="https://user-images.githubusercontent.com/40744698/61210488-8ed3ff80-a6f4-11e9-83bf-cd7436ac35c9.PNG">
