### PR TITLE
#167308613 Add unit tests for update property price

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -114,19 +114,22 @@ export default class PropertyController {
       const updated_on = await Property.updatePrice(price, parseInt(propertyId, 10));
       if (!updated_on) return Helpers.serverInternalError(res);
       return res.status(200).json({
-        id: propertyId,
-        status: prop.status,
-        type: prop.property_type,
-        state: prop.state,
-        city: prop.city,
-        address: prop.address,
-        price: parseFloat(price),
-        created_on: prop.created_on,
-        image_url: prop.image_url,
-        purpose: prop.purpose,
-        other_type: prop.other_type,
-        description: prop.description,
-        updated_on
+        status: 'success',
+        data: {
+          id: propertyId,
+          status: prop.status,
+          type: prop.property_type,
+          state: prop.state,
+          city: prop.city,
+          address: prop.address,
+          price: parseFloat(price),
+          created_on: prop.created_on,
+          image_url: prop.image_url,
+          purpose: prop.purpose,
+          other_type: prop.other_type,
+          description: prop.description,
+          updated_on
+        }
       });
     } catch (err) {
       return Helpers.serverInternalError(res);

--- a/API/src/data/db/index.js
+++ b/API/src/data/db/index.js
@@ -24,10 +24,6 @@ class DB {
 const db = new DB();
 
 /* eslint no-console : 0 */
-db.pool.on('connect', () => {
-  console.log('connected to the db');
-});
-
 db.pool.on('error', () => {
   console.log('some database error have occurred');
   process.exit(-1);

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -129,7 +129,6 @@ export default class Property extends PropertyModel {
 
   static async update(valueArr, id) {
     const [purpose, state, status, type, ...others] = valueArr;
-    console.log(purpose, state, status, type);
     const relationsId = await Property.generateAllRelationId(
       state,
       status,

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -277,7 +277,7 @@ describe('Property Route Endpoints', () => {
     });
     it("should return a resource not found error response if the property ID specified doesn't match the existing property adverts", done => {
       request
-        .get(`/api/v1/property/67585959500`)
+        .get(`/api/v1/property/675`)
         .set('token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)
@@ -290,10 +290,10 @@ describe('Property Route Endpoints', () => {
     });
   });
   // update property
-  describe('UPDATE api/v1/property/:property-id', () => {
+  describe('PUT api/v1/property/:property-id', () => {
     it('should allow an authenticated user(Agent) to successfully update his/her property advert if he/she provides valid parameters', done => {
       request
-        .patch(`/api/v1/property/${testPropertyId}`)
+        .put(`/api/v1/property/${testPropertyId}`)
         .field('price', 700000)
         .field('state', 'Ekiti')
         .field('city', 'Ado')
@@ -320,14 +320,14 @@ describe('Property Route Endpoints', () => {
             'purpose',
             'other_type',
             'description',
-            'update_on'
+            'updated_on'
           );
         })
         .end(done);
     });
     it('should prevent an unathenticated user from updating a property advert', done => {
       request
-        .patch('/api/v1/property/2')
+        .put('/api/v1/property/2')
         .field('status', 'Available')
         .field('price', 80000.0)
         .field('state', 'Lagos')
@@ -347,7 +347,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent a user with an Invalid token from updating a property advert', done => {
       request
-        .patch('/api/v1/property/2')
+        .put('/api/v1/property/2')
         .field('status', 'Available')
         .field('price', 80000.0)
         .field('state', 'Lagos')
@@ -368,7 +368,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent a user from updating a property advert if he/she provides invalid input parameters', done => {
       request
-        .patch('/api/v1/property/2')
+        .put('/api/v1/property/2')
         .field('status', 'Available')
         .field('price', 'rhjfioo')
         .field('state', 'Lagos')
@@ -389,7 +389,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent a user from updating a property advert with empty field parameters', done => {
       request
-        .patch('/api/v1/property/2')
+        .put('/api/v1/property/2')
         .field('status', 'Available')
         .field('price', '')
         .field('state', 'Lagos')
@@ -410,7 +410,7 @@ describe('Property Route Endpoints', () => {
     });
     it('should prevent any user except an Admin from updating a property advert posted by another user', done => {
       request
-        .patch('/api/v1/property/1')
+        .put('/api/v1/property/1')
         .field('status', 'Available')
         .field('state', 'Lagos')
         .field('purpose', 'For Rent')
@@ -427,11 +427,121 @@ describe('Property Route Endpoints', () => {
     });
     it("should return a 404 response code whenever a user attempts to update a property that doesn't exist", done => {
       request
-        .patch('/api/v1/property/78787058689')
+        .put('/api/v1/property/787')
         .field('status', 'Available')
         .field('state', 'Lagos')
         .field('purpose', 'For Rent')
         .set('Connection', 'keep-alive')
+        .set('token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(404)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('404 Not Found');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+  });
+  // update property price
+  describe('PATCH api/v1/property/:property-id', () => {
+    it('should allow an authenticated user(Agent) to successfully update the price of  his/her property advert', done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}`)
+        .send({ price: 4000.0 })
+        .set('token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+          const { status, data } = res.body;
+          expect(status).to.equal('success');
+          expect(data).to.have.all.keys(
+            'id',
+            'status',
+            'type',
+            'state',
+            'city',
+            'address',
+            'price',
+            'created_on',
+            'image_url',
+            'purpose',
+            'other_type',
+            'description',
+            'updated_on'
+          );
+        })
+        .end(done);
+    });
+    it("should prevent a user who doesn't provide an access token from updating the price of his/her property advert", done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}`)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Required');
+        })
+        .end(done);
+    });
+    it('should prevent a user with an Invalid token from updating the price of his/her property advert', done => {
+      request
+        .patch(`/api/v1/property/${testPropertyId}`)
+        .set('token', inValidToken)
+        .expect('Content-Type', /json/)
+        .expect(401)
+        .expect(res => {
+          const { status, error } = res.body;
+          expect(status).to.equal('401 Unauthorized');
+          expect(error).to.equal('Access token is Invalid');
+        })
+        .end(done);
+    });
+    it('should prevent any user except an Admin from updating the price of a property advert posted by another user', done => {
+      request
+        .patch(`/api/v1/property/1`)
+        .set('token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(403)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('403 Forbidden Request');
+          expect(res.body).to.have.all.keys('status', 'error');
+        })
+        .end(done);
+    });
+    it('should prevent a user from updating the price of a property advert with invalid input parameters', done => {
+      request
+        .patch('/api/v1/property/2')
+        .send({ price: 'rhjfioo' })
+        .set('token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Bad Request');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
+        })
+        .end(done);
+    });
+    it('should respond with an error that tells the user he/she cannot send empty fields as a request to update the price of a property advert', done => {
+      request
+        .patch('/api/v1/property/2')
+        .send({ price: '' })
+        .set('token', validToken)
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(res => {
+          const { status } = res.body;
+          expect(status).to.equal('400 Bad Request');
+          expect(res.body).to.have.all.keys('status', 'error', 'errors');
+        })
+        .end(done);
+    });
+    it("should return a resource not found error response whenever a user attempts to update the price of a property that doesn't exist", done => {
+      request
+        .patch('/api/v1/property/787')
         .set('token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)
@@ -511,7 +621,7 @@ describe('Property Route Endpoints', () => {
     });
     it("should return a resource not found error response whenever a user attempts to mark a property that doesn't exist sold/rented", done => {
       request
-        .patch('/api/v1/property/78787058689/sold')
+        .patch('/api/v1/property/787/sold')
         .set('token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)
@@ -579,7 +689,7 @@ describe('Property Route Endpoints', () => {
     });
     it("should return a resource not found error response whenever a user attempts to delete a property that doesn't exist", done => {
       request
-        .delete('/api/v1/property/78787058689')
+        .delete('/api/v1/property/787')
         .set('token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)


### PR DESCRIPTION
#### What does this PR do?
Add unit tests  for the API endpoint `/api/v1/property/:property-id` that enables users to update the price for their property advert, checking the following:
- The app should prevent a user who has not been authenticated from updating the price a property advert
- The app should prevent a user from updating the price of an advert if he/she provides an invalid token in the request header
- The app should prevent an authenticated user from updating the price of a property advert if he/she provides invalid input parameters in the body of the request
- The app should prevent an authenticated user from updating the price of a property advert if he/she provides empty fields or doesn't provide all the required field parameters
- The app should allow users who have been authenticated to successfully update their property advert if they provide valid data 
- The app should prevent a user from updating a property advert posted by another user except the user is an admin
- The app should ensure a user gets an appropriate response if he/she attempts to update a property that doesn't exist

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify existing test script covering the test cases on updating a property to handle PUT request scenarios
- Create test script that checks the scenarios described above
- Modify the response data on the controller method

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ch-tests-update-price-167308613 branch and run `npm install`
- Once all the dependencies are installed, run `npm test`

#### What are the relevant pivotal tracker stories?
#167308613

#### Screenshot
<img width="804" alt="put-patch" src="https://user-images.githubusercontent.com/40744698/61259157-e57f1f00-a770-11e9-87ab-626acb15a32c.PNG">
