### PR TITLE
#167309302 Add DB implementation to mark property sold/rent

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -118,7 +118,7 @@ export default class PropertyController {
         data: {
           id: propertyId,
           status: prop.status,
-          type: prop.property_type,
+          type: prop.type,
           state: prop.state,
           city: prop.city,
           address: prop.address,
@@ -143,7 +143,7 @@ export default class PropertyController {
         body.purpose || prop.purpose,
         body.state || prop.state,
         body.status || prop.status,
-        body.type || prop.property_type,
+        body.type || prop.type,
         parseFloat(body.price) || prop.price,
         body.city || prop.city,
         body.address || prop.address,
@@ -182,12 +182,17 @@ export default class PropertyController {
     try {
       const { prop: property } = req;
       const { available } = req.query;
-      if (available === 'true') property.status = 'Available';
+      if (available === 'true') property.status = 'available';
       if (!available)
-        property.status = property.purpose === 'For Rent' ? 'Rented' : 'Sold';
-      await Property.updateAndSave(property);
+        property.status = property.purpose === 'for rent' ? 'rented' : 'sold';
+      const updated_on = await Property.markSoldOrRented(
+        property.id,
+        property.purpose,
+        property.status
+      );
+      if (!updated_on) return Helpers.serverInternalError(res);
       return res.status(200).json({
-        status: 'Success',
+        status: 'success',
         data: {
           id: property.id,
           status: property.status,
@@ -198,16 +203,14 @@ export default class PropertyController {
           price: property.price,
           created_on: property.created_on,
           image_url: property.image_url,
-          imageName: property.imageName,
           purpose: property.purpose,
-          otherType: property.otherType
+          other_type: property.other_type,
+          description: property.description,
+          updated_on
         }
       });
     } catch (e) {
-      return res.status(500).json({
-        status: '500 Server Interval Error',
-        error: 'Something went wrong while processing your request, Do try again'
-      });
+      return Helpers.serverInternalError(res);
     }
   }
 

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -127,6 +127,19 @@ export default class Property extends PropertyModel {
     return updated_on;
   }
 
+  static async markSoldOrRented(id, purpose, status) {
+    const purposeId = Property.getRelationId('purposes', purpose);
+    const statusId = Property.getRelationId('status', status);
+    const [statusID, purposeID] = await Promise.all([statusId, purposeId]);
+    const text = `UPDATE properties SET status = $1, purpose = $2, updated_on = $3
+    WHERE id = $4 RETURNING updated_on
+    `;
+    const {
+      rows: [{ updated_on }]
+    } = await db.queryWithParams(text, [statusID, purposeID, moment(), id]);
+    return updated_on;
+  }
+
   static async update(valueArr, id) {
     const [purpose, state, status, type, ...others] = valueArr;
     const relationsId = await Property.generateAllRelationId(
@@ -155,9 +168,10 @@ export default class Property extends PropertyModel {
     properties.owner,
     status.name status,
     states.name state,
+    properties.price,
     properties.city,
     properties.address,
-    types.name property_type,
+    types.name "type",
     properties.created_on,
     properties.image_url,
     properties.other_type,

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -575,8 +575,9 @@ describe('Property Route Endpoints', () => {
             'created_on',
             'image_url',
             'purpose',
-            'image_name',
-            'otherType'
+            'other_type',
+            'description',
+            'updated_on'
           );
         })
         .end(done);


### PR DESCRIPTION
#### What does this PR do?
Add database implementation to the mark a property sold/rented endpoint
#### Description of Task to be completed?
Carry out the following Tasks 
- Add a method in `API/src/services/property.js` for handling the database interaction necessary to update a property advert's status
- Modify `markProperty` on method on property controller for database transaction
- Make changes to the response expected by the test cases for mark a property as sold endpoint

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-mark-sold-167309302 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Launch postman once the app is up to start testing the endpoint
- Ensure to include a .env file containing a PORT variable whose value should correspond to a port with which the App would listen for requests

#### Any background context you want to provide?
- All API endpoints for this app are prefixed with `api/v1`, hence testing locally would implies the URI is formed as `http://localhost:{{PORT}}/api/v1/{{endpoint}}` where endpoint for mark as sold is `/property/:property-id/sold`
- Look up the request field specification for post property in the ADC requirement on page 13

#### What are the relevant pivotal tracker stories?
#167309302

#### Screenshot
<img width="943" alt="mark-sold" src="https://user-images.githubusercontent.com/40744698/61262831-ae176f00-a77e-11e9-9b2b-3de71ad033d5.PNG">
<img width="867" alt="test-for-mark" src="https://user-images.githubusercontent.com/40744698/61262857-c1c2d580-a77e-11e9-84da-968eb7638ba1.PNG">
