### PR TITLE
#167310035 Implement DB interaction for delete endpoint

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -219,18 +219,16 @@ export default class PropertyController {
       prop: { id: propertyId }
     } = req;
     try {
-      await Property.deleteById(propertyId);
+      const id = await Property.deleteById(propertyId);
+      if (!id) return Helpers.serverInternalError(res);
       return res.status(200).json({
-        status: 'Success',
+        status: 'success',
         data: {
           message: `Successfully deleted property of id : ${propertyId}`
         }
       });
     } catch (e) {
-      return res.status(500).json({
-        status: '500 Server Interval Error',
-        error: 'Something went wrong while processing your request, Do try again'
-      });
+      return Helpers.serverInternalError(res);
     }
   }
 }

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -254,17 +254,12 @@ export default class Property extends PropertyModel {
     };
   }
 
-  static async updateAndSave(property) {
-    const propIndex = properties.findIndex(({ id }) => id === property.id);
-    properties.splice(propIndex, 1, property);
-  }
-
   static async deleteById(propertyId) {
-    const propIndex = properties.findIndex(({ id }) => id === propertyId);
-    const removed = properties.splice(propIndex, 1);
-    const isDeleted = removed.length === 1 ? true : new Error('not deleted');
-    if (isDeleted) return isDeleted;
-    throw isDeleted;
+    const text = `DELETE FROM properties WHERE id = $1 RETURNING id`;
+    const {
+      rows: [{ id }]
+    } = await db.queryWithParams(text, [propertyId]);
+    return id;
   }
 
   static async fetchByType(queryObj) {


### PR DESCRIPTION
#### What does this PR do?
Add database interaction to the  API endpoint `api/v1/property/:property-id/` to enable authenticated users to delete  their property advert on the App

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify static method for handling delete functionality in the property controller
- Modify the `deleteById` function to include database transaction


#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-delete-property-167310035 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a DELETE request to the URI `http://localhost:{{port}}/api/v1/property/:property-id` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167310035

#### Screenshot
<img width="954" alt="delere" src="https://user-images.githubusercontent.com/40744698/61264698-5b8d8100-a785-11e9-85c3-d51131609c69.PNG">
<img width="835" alt="delete" src="https://user-images.githubusercontent.com/40744698/61264710-60523500-a785-11e9-8bf0-28cf577f35e9.PNG">
