### PR TITLE
#167315419 Implement DB interaction for filtering property adverts

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -6,10 +6,10 @@ export default class PropertyController {
   static async getAllProperties(req, res) {
     try {
       let allProperties;
-      const isQueryExist = Object.keys(req.query).length;
-      if (isQueryExist) allProperties = await Property.fetchByType(req.query);
+      const isQueryExist = req.query.type;
+      if (isQueryExist) allProperties = await Property.fetchByType(req.query.type);
       else allProperties = await Property.fetchAll();
-      if (!allProperties)
+      if (!allProperties.length)
         return res.status(404).json({
           status: '404 Not Found',
           error: "The property adverts you request aren't available"
@@ -19,7 +19,6 @@ export default class PropertyController {
         data: allProperties
       });
     } catch (e) {
-      console.log(e.stack);
       return Helpers.serverInternalError(res);
     }
   }

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -194,7 +194,8 @@ describe('Property Route Endpoints', () => {
             'owner_email',
             'owner_phone_number',
             'purpose',
-            'other_type'
+            'other_type',
+            'description'
           );
         })
         .end(done);
@@ -210,7 +211,7 @@ describe('Property Route Endpoints', () => {
             body: { status, data }
           } = res;
           const { type } = data[0];
-          expect(type).to.equal('2 Bedroom');
+          expect(type).to.equal('2 bedroom');
           expect(status).to.equal('success');
           expect(data).to.be.an('array');
           expect(data[0]).to.have.all.keys(
@@ -226,14 +227,15 @@ describe('Property Route Endpoints', () => {
             'owner_email',
             'owner_phone_number',
             'purpose',
-            'other_type'
+            'other_type',
+            'description'
           );
         })
         .end(done);
     });
     it('should return a resource not found error response when a user filters for property adverts of a specific type that is currently not available on the App', done => {
       request
-        .get(`/api/v1/property?type=Land`)
+        .get(`/api/v1/property?type=FarmLand`)
         .set('token', validToken)
         .expect('Content-Type', /json/)
         .expect(404)

--- a/API/src/utils/helpers.js
+++ b/API/src/utils/helpers.js
@@ -20,10 +20,10 @@ class Helpers {
     }
   }
 
-  static serverInternalError(res) {
+  static serverInternalError(res, msg = undefined) {
     return res.status(500).json({
       status: '500 Server Interval Error',
-      error: 'Something went wrong while processing your request, Do try again'
+      error: msg || 'Something went wrong while processing your request, Do try again'
     });
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Add implementation that enables Users to filter for a specific property type stored in the database 

#### Description of Task to be completed?
Carry out the following Tasks 
- Modify the `getAllProperties` method of the propertyController 
- Modify the `fetchByType` method in `API/src/services/property.js`
- Remove redundant function in `API/src/services/property.js`

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-by-type-167315419 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167315419

#### Screenshot
<img width="908" alt="Capture" src="https://user-images.githubusercontent.com/40744698/61290920-f3f72600-a7c4-11e9-8eb1-31ce1b4533e8.PNG">
<img width="920" alt="by_type" src="https://user-images.githubusercontent.com/40744698/61290939-fb1e3400-a7c4-11e9-8a23-97ab984f2550.PNG">
