### PR TITLE
#167316524 dd DB interaction for get single property

### DIFF
--- a/API/src/controllers/propertyController.js
+++ b/API/src/controllers/propertyController.js
@@ -35,7 +35,7 @@ export default class PropertyController {
           error: 'The property advert you have requested is not available'
         });
       return res.status(200).json({
-        status: 'Success',
+        status: 'success',
         data: property
       });
     } catch (e) {

--- a/API/src/services/property.js
+++ b/API/src/services/property.js
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import PropertyModel from '../models/propertyModel';
-import UserServices from './user';
 import db from '../data/db/index';
 
 export default class Property extends PropertyModel {
@@ -193,41 +192,35 @@ export default class Property extends PropertyModel {
   }
 
   static async fetchById(propertyId) {
-    const property = await Property.findById(propertyId);
-    if (!property) return property;
+    const text = `
+    SELECT
+    properties.id,
+    status.name status,
+	  types.name "type",
+    states.name state,
+    properties.city,
+    properties.address,
+	  properties.price,
+    properties.created_on,
+    properties.image_url,
+    users.email owner_email,
+	  users.phone_number owner_phone_number,
+	  purposes.name purpose,
+    properties.other_type,
+    properties.description
+ FROM
+    properties
+ INNER JOIN status ON status.id = properties.status
+ INNER JOIN states ON states.id = properties.state
+ INNER JOIN types ON types.id = properties.type
+ INNER JOIN purposes ON purposes.id = properties.purpose
+ INNER JOIN users ON users.id = properties.owner
+ WHERE properties.id = $1
+ `;
     const {
-      id,
-      status,
-      type,
-      state,
-      city,
-      address,
-      price,
-      created_on,
-      image_url,
-      purpose,
-      otherType,
-      owner
-    } = property;
-    const {
-      email: ownerEmail,
-      phoneNumber: ownerPhoneNumber
-    } = await UserServices.findById(owner);
-    return {
-      id,
-      status,
-      type,
-      state,
-      city,
-      address,
-      price,
-      created_on,
-      image_url,
-      ownerEmail,
-      ownerPhoneNumber,
-      purpose,
-      otherType
-    };
+      rows: [property]
+    } = await db.queryWithParams(text, [parseInt(propertyId, 10)]);
+    return property;
   }
 
   static async deleteById(propertyId) {

--- a/API/src/test/property.test.js
+++ b/API/src/test/property.test.js
@@ -273,7 +273,8 @@ describe('Property Route Endpoints', () => {
             'owner_email',
             'owner_phone_number',
             'purpose',
-            'other_type'
+            'other_type',
+            'description'
           );
         })
         .end(done);


### PR DESCRIPTION

#### What does this PR do?
Add database interaction to view a property endpoint (`/api/v1/property/:property-id`)
#### Description of Task to be completed?
Carry out the following Tasks 
- Modify `getProperty` method in property controller
- Modify the  `fetchById` method to the property service Class


#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-DB-single-property-167316524 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing it has started running on some port, startup postman for testing
- Make a GET request to the URI `http://localhost:{{port}}/api/v1/property/:property-id` to test the endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Run the unit tests using the command `npm test`

#### What are the relevant pivotal tracker stories?
#167316524

#### Screenshot
<img width="895" alt="get-single" src="https://user-images.githubusercontent.com/40744698/61293667-1fc9da00-a7cc-11e9-8ba2-51477816336e.PNG">
<img width="952" alt="sing" src="https://user-images.githubusercontent.com/40744698/61293678-27897e80-a7cc-11e9-9613-fc275a4c5352.PNG">
