### PR TITLE
#167636896 Modify token delivery to client

### DIFF
--- a/API/src/app.js
+++ b/API/src/app.js
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import { urlencoded, json } from 'body-parser';
 import cors from 'cors';
 import swaggerUI from 'swagger-ui-express';
@@ -27,6 +28,9 @@ app.use(urlencoded({ extended: true }));
 
 // parse application/json
 app.use(json());
+
+// parse cookies
+app.use(cookieParser());
 
 // render swagger UI
 app.use('/api/v1/api-docs', swaggerUI.serve, swaggerUI.setup(doc));

--- a/API/src/controllers/authController.js
+++ b/API/src/controllers/authController.js
@@ -10,6 +10,7 @@ class Auth {
       const user = new User(first_name, last_name, email, address, pass, phone_number);
       const { id, is_admin } = await user.save();
       const token = User.generateToken(id, is_admin);
+      res.cookie('token', token, { maxAge: 86400000, httpOnly: true });
       return res.status(201).json({
         status: 'success',
         data: {
@@ -34,6 +35,7 @@ class Auth {
       if (isMatch) {
         const { id, first_name, last_name, is_admin } = user;
         const token = User.generateToken(id, is_admin);
+        res.cookie('token', token, { maxAge: 86400000, httpOnly: true });
         return res.status(200).json({
           status: 'success',
           data: {

--- a/API/src/middlewares/authenticate.js
+++ b/API/src/middlewares/authenticate.js
@@ -6,10 +6,10 @@ config();
 export default class Authenticate {
   static async verify(req, res, next) {
     const {
-      body: { token: bodyToken = null },
-      headers: { token: headerToken = null }
+      headers: { token: headerToken = null },
+      cookies: { token: cookieToken = null }
     } = req;
-    const token = !headerToken ? bodyToken : headerToken;
+    const token = !cookieToken ? headerToken : cookieToken;
 
     if (!token) {
       res.status(401).json({

--- a/API/src/models/userModel.js
+++ b/API/src/models/userModel.js
@@ -1,14 +1,5 @@
 export default class User {
-  constructor(
-    id,
-    firstName,
-    lastName,
-    email,
-    address,
-    password,
-    phone,
-    isAdmin
-  ) {
+  constructor(id, firstName, lastName, email, address, password, phone, isAdmin) {
     this.id = id;
     this.first_name = firstName;
     this.last_name = lastName;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,6 +1617,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
     "cloudinary": "^1.14.0",
+    "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION

#### What does this PR do?
- Implement the delivery of the generated jwt token as a cookie during signup and login
#### Description of Task to be completed?
- Add res.cookie to login and signup controller methods in the `AuthController` so that they are used to send the token as a cookie to the client
- Add logic to check for authentication token in cookies in the `verifyToken` function

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the rf-API-wrap-token-167636896 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signup` to test the signup endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Post the data fields described in the entity specification for a User in the requirement
- To run the corresponding unit test, kill or terminal all node processes ( cmd/ctrl + c ) and then run `npm run test-dev`


#### What are the relevant pivotal tracker stories?
#167636896
